### PR TITLE
Add support for service account authentication

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,8 @@ setup(
     install_requires=[
         "singer-python==5.9.0",
         "requests==2.22.0",
-        "backoff==1.8.0"
+        "backoff==1.8.0",
+        "jwt==0.6.1"
     ],
     extras_require={
         'dev': [

--- a/tap_google_analytics/__init__.py
+++ b/tap_google_analytics/__init__.py
@@ -64,8 +64,16 @@ def do_discover(client, profile_id):
     write_catalog(catalog)
 
 def main():
-    required_config_keys = ['start_date', 'client_id', 'client_secret', 'refresh_token', 'view_id']
+    required_config_keys = ['start_date', 'view_id', 'auth_method']
     args = singer.parse_args(required_config_keys)
+
+    if args.config['auth_method'] == "oauth2":
+         additional_config_keys = ['client_id', 'client_secret', 'refresh_token']
+    elif args.config['auth_method'] == "service_account":
+        additional_config_keys = ['client_email', 'private_key']
+    else:
+        raise ValueError("Config has invalid auth_method: {}".format(args.config['auth_method']))
+    singer.utils.check_config(args.config, additional_config_keys)
 
     config = args.config
     client = Client(config)

--- a/tap_google_analytics/__init__.py
+++ b/tap_google_analytics/__init__.py
@@ -65,15 +65,14 @@ def do_discover(client, profile_id):
 
 def main():
     required_config_keys = ['start_date', 'view_id', 'auth_method']
-    args = singer.parse_args(required_config_keys)
+    if "refresh_token" in args.config:  # if refresh_token in config assume OAuth2 credentials
+        args.config['auth_method'] = "oauth2"
+        required_config_keys.extend(['client_id', 'client_secret', 'refresh_token'])
+    else:  # otherwise, assume Service Account details should be present
+        args.config['auth_method'] = "service_account"
+        required_config_keys.extend(['client_email', 'private_key'])
 
-    if args.config['auth_method'] == "oauth2":
-         additional_config_keys = ['client_id', 'client_secret', 'refresh_token']
-    elif args.config['auth_method'] == "service_account":
-        additional_config_keys = ['client_email', 'private_key']
-    else:
-        raise ValueError("Config has invalid auth_method: {}".format(args.config['auth_method']))
-    singer.utils.check_config(args.config, additional_config_keys)
+    args = singer.parse_args(required_config_keys)
 
     config = args.config
     client = Client(config)

--- a/tap_google_analytics/client.py
+++ b/tap_google_analytics/client.py
@@ -22,7 +22,7 @@ def should_giveup(e):
 
 class Client():
     def __init__(self, config):
-        self.auth_method = config.get("auth_method", "oauth2")
+        self.auth_method = config['auth_method']
         if self.auth_method == "oauth2":
             self.refresh_token = config["refresh_token"]
             self.client_id = config["client_id"]


### PR DESCRIPTION
# Description of change
Enables the possibility of using a Service Account to connect to the API

# QA steps
 - [ ] automated tests passing
 - [x] manual qa steps passing (list below)
    - Did a 'discovery' with both OAuth2 and Service Account credentials
 
# Risks
 -  None
 
# Rollback steps
 - revert this branch
