### PR TITLE
Parse end_date string from config

### DIFF
--- a/tap_google_analytics/__init__.py
+++ b/tap_google_analytics/__init__.py
@@ -20,7 +20,7 @@ def get_end_date(config):
 
     This can be overridden by the `end_date` config.json value.
     """
-    if 'end_date' in config: return config['end_date']
+    if 'end_date' in config: return utils.strptime_to_utc(config['end_date'])
     return (utils.now() - timedelta(1)).replace(hour=0, minute=0, second=0, microsecond=0)
 
 def do_sync(client, config, catalog, state):


### PR DESCRIPTION
# Description of change
`end_date` from the config file provided was not being parsed into a `datetime` object leading to an exception later in the code.

# QA steps
 - [ ] automated tests passing
 - [x] manual qa steps passing (list below)
   - Pulled data with an `end_date`
 
# Risks
 - None
 
# Rollback steps
 - revert this branch
