### PR TITLE
Add support for multiple reports in the tap config

### DIFF
--- a/tap_google_analytics/__init__.py
+++ b/tap_google_analytics/__init__.py
@@ -56,11 +56,11 @@ def do_sync(client, config, catalog, state):
 
         sync_report(client, schema, report, start_date, end_date, state)
 
-def do_discover(client, profile_id):
+def do_discover(client, config):
     """
     Make request to discover.py and write result to stdout.
     """
-    catalog = discover(client, profile_id)
+    catalog = discover(client, config)
     write_catalog(catalog)
 
 def main():
@@ -84,7 +84,7 @@ def main():
         raise Exception("DEPRECATED: Use of the 'properties' parameter is not supported. Please use --catalog instead")
 
     if args.discover:
-        do_discover(client, config["view_id"])
+        do_discover(client, config)
     else:
         do_sync(client, config, catalog, state)
 


### PR DESCRIPTION
# Description of change
Add support for multiple reports in the tap through a new config value `report_names`.

# QA steps
 - [ ] automated tests passing
 - [x] manual qa steps passing (list below)
Ran the tap with multiple reports and discovery/syncing worked as expected 

# Risks
 - Any connections without a report_names config value will fail
 
# Rollback steps
 - revert this branch
