### PR TITLE
Log top level exceptions as critical

### DIFF
--- a/tap_google_analytics/__init__.py
+++ b/tap_google_analytics/__init__.py
@@ -7,6 +7,8 @@ from .client import Client
 from .discover import discover
 from .sync import sync_report
 
+LOGGER = singer.get_logger()
+
 def get_start_date(config, state, tap_stream_id):
     """
     Returns a date bookmark in state for the given stream, or the
@@ -71,6 +73,7 @@ def do_discover(client, config):
     catalog = discover(client, config, config['view_id'])
     write_catalog(catalog)
 
+@utils.handle_top_exception(LOGGER)
 def main():
     required_config_keys = ['start_date', 'view_id']
     args = singer.parse_args(required_config_keys)


### PR DESCRIPTION
# Description of change
It appears that we missed the singer standard of logging top-level exceptions as `CRITICAL` in order to parse out the final error mesage successfully.

This PR adds that so it gets wrapped into 1.0.0.

# QA steps
 - [ ] automated tests passing
 - [X] manual qa steps passing (list below)
    - Ran a local test connection and confirmed that it logged `CRITICAL`
 
# Risks
 - Low, this is additive and logging-related
 
# Rollback steps
 - revert this branch
