### PR TITLE
Feature/multiple profiles

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
           name: 'pylint'
           command: |
             source /usr/local/share/virtualenvs/tap-google-analytics/bin/activate
-            pylint tap_google_analytics --disable 'broad-except,chained-comparison,empty-docstring,fixme,invalid-name,line-too-long,missing-class-docstring,missing-function-docstring,missing-module-docstring,no-else-raise,no-else-return,too-few-public-methods,too-many-arguments,too-many-branches,too-many-lines,too-many-locals,ungrouped-imports,wrong-spelling-in-comment,wrong-spelling-in-docstring,bad-whitespace,cell-var-from-loop'
+            pylint tap_google_analytics --disable 'broad-except,chained-comparison,empty-docstring,fixme,invalid-name,line-too-long,missing-class-docstring,missing-function-docstring,missing-module-docstring,no-else-raise,no-else-return,too-few-public-methods,too-many-arguments,too-many-branches,too-many-lines,too-many-locals,ungrouped-imports,wrong-spelling-in-comment,wrong-spelling-in-docstring,bad-whitespace'
       - run:
           name: 'Unit Tests'
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
           name: 'pylint'
           command: |
             source /usr/local/share/virtualenvs/tap-google-analytics/bin/activate
-            pylint tap_google_analytics --disable 'broad-except,chained-comparison,empty-docstring,fixme,invalid-name,line-too-long,missing-class-docstring,missing-function-docstring,missing-module-docstring,no-else-raise,no-else-return,too-few-public-methods,too-many-arguments,too-many-branches,too-many-lines,too-many-locals,ungrouped-imports,wrong-spelling-in-comment,wrong-spelling-in-docstring,bad-whitespace'
+            pylint tap_google_analytics --disable 'broad-except,chained-comparison,empty-docstring,fixme,invalid-name,line-too-long,missing-class-docstring,missing-function-docstring,missing-module-docstring,no-else-raise,no-else-return,too-few-public-methods,too-many-arguments,too-many-branches,too-many-lines,too-many-locals,ungrouped-imports,wrong-spelling-in-comment,wrong-spelling-in-docstring,bad-whitespace,cell-var-from-loop'
       - run:
           name: 'Unit Tests'
           command: |

--- a/tap_google_analytics/__init__.py
+++ b/tap_google_analytics/__init__.py
@@ -1,3 +1,4 @@
+import functools
 import itertools
 from datetime import timedelta
 
@@ -86,7 +87,8 @@ def do_sync(client, config, catalog, state):
         current_view = state.get('currently_syncing_view')
         if current_view:
             if current_view in view_ids:
-                view_ids = list(itertools.dropwhile(lambda v: v != current_view, view_ids))
+                view_not_current = functools.partial(lambda cv, v: v != cv, current_view)
+                view_ids = list(itertools.dropwhile(view_not_current, view_ids))
             else:
                 state.pop('currently_syncing_view', None)
 

--- a/tap_google_analytics/__init__.py
+++ b/tap_google_analytics/__init__.py
@@ -120,7 +120,7 @@ def do_discover(client, config):
     """
     Make request to discover.py and write result to stdout.
     """
-    catalog = discover(client, config, config['view_id'])
+    catalog = discover(client, config, get_view_ids(config))
     write_catalog(catalog)
 
 def validate_config_view_ids(config):

--- a/tap_google_analytics/__init__.py
+++ b/tap_google_analytics/__init__.py
@@ -1,3 +1,4 @@
+import itertools
 from datetime import timedelta
 
 import singer
@@ -9,12 +10,35 @@ from .sync import sync_report
 
 LOGGER = singer.get_logger()
 
-def get_start_date(config, state, tap_stream_id):
+
+# TODO: Unit test this
+def clean_state_for_report(config, state, tap_stream_id):
+    top_level_bookmark = utils.strptime_to_utc(get_bookmark(state,
+                                                            tap_stream_id,
+                                                            'last_report_date',
+                                                            default=config['start_date']))
+    if top_level_bookmark:
+        LOGGER.info("%s - Converting state to multi-profile format.", tap_stream_id)
+        view_ids = get_view_ids(config)
+        for view_id in view_ids:
+            state = singer.write_bookmark(state,
+                                          tap_stream_id,
+                                          view_id,
+                                          {'last_report_date': report_date.strftime("%Y-%m-%d")})
+        state = singer.clear_bookmark(state, tap_stream_id, 'last_report_date')
+        singer.write_state(state)
+    return state
+
+def get_start_date(config, view_id, state, tap_stream_id):
     """
     Returns a date bookmark in state for the given stream, or the
     `start_date` from config, if no bookmark exists.
     """
-    return utils.strptime_to_utc(get_bookmark(state, tap_stream_id, 'last_report_date', default=config['start_date']))
+    return utils.strptime_to_utc(get_bookmark(state,
+                                              tap_stream_id,
+                                              view_id,
+                                              default={}).get('last_report_date',
+                                                              config['start_date']))
 
 def get_end_date(config):
     """
@@ -27,6 +51,9 @@ def get_end_date(config):
         return utils.strptime_to_utc(config['end_date'])
     return utils.now().replace(hour=0, minute=0, second=0, microsecond=0)
 
+def get_view_ids(config):
+    return config.get('view_ids') or [config.get('view_id')]
+
 def do_sync(client, config, catalog, state):
     """
     Translate metadata into a set of metrics and dimensions and call out
@@ -34,6 +61,9 @@ def do_sync(client, config, catalog, state):
     """
     selected_streams = catalog.get_selected_streams(state)
     for stream in selected_streams:
+        # Transform state for this report to new format before proceeding
+        state = clean_state_for_report(config, state, stream.tap_stream_id)
+
         metrics = []
         dimensions = []
         mdata = metadata.to_map(stream.metadata)
@@ -49,13 +79,24 @@ def do_sync(client, config, catalog, state):
                 elif field_mdata.get('behavior') == 'DIMENSION':
                     dimensions.append(field_name)
 
-        report = {"profile_id": config['view_id'],
-                  "name": stream.stream,
-                  "id": stream.tap_stream_id,
-                  "metrics": metrics,
-                  "dimensions": dimensions}
+        view_ids = get_view_ids(config)
 
-        start_date = get_start_date(config, state, report['id'])
+        # NB: Resume from previous view for this report, dropping all
+        # views before it to keep streams moving forward
+        current_view = state.get('currently_syncing_view')
+        if current_view:
+            if current_view in view_ids:
+                view_ids = list(itertools.dropwhile(lambda v: v != current_view, view_ids))
+            else:
+                state.pop('currently_syncing_view', None)
+
+        reports_per_view = [{"profile_id": view_id,
+                             "name": stream.stream,
+                             "id": stream.tap_stream_id,
+                             "metrics": metrics,
+                             "dimensions": dimensions}
+                            for view_id in view_ids]
+
         end_date = get_end_date(config)
 
         schema = stream.schema.to_dict()
@@ -66,7 +107,14 @@ def do_sync(client, config, catalog, state):
             stream.key_properties
             )
 
-        sync_report(client, schema, report, start_date, end_date, state)
+        for report in reports_per_view:
+            state['currently_syncing_view'] = report['profile_id']
+            singer.write_state(state)
+
+            start_date = get_start_date(config, report['profile_id'], state, report['id'])
+            sync_report(client, schema, report, start_date, end_date, state)
+        state.pop('currently_syncing_view', None)
+        singer.write_state(state)
 
 def do_discover(client, config):
     """
@@ -75,10 +123,17 @@ def do_discover(client, config):
     catalog = discover(client, config, config['view_id'])
     write_catalog(catalog)
 
+def validate_config_view_ids(config):
+    if 'view_id' not in config and 'view_ids' not in config:
+        raise Exception("Config Validation Error: config.json MUST contain one of: view_ids, view_id.")
+    if 'view_id' in config and 'view_ids' in config:
+        raise Exception("Config Validation Error: config.json must ONLY contain view_id or view_ids, but not both.")
+
 @utils.handle_top_exception(LOGGER)
 def main():
-    required_config_keys = ['start_date', 'view_id']
+    required_config_keys = ['start_date']
     args = singer.parse_args(required_config_keys)
+    validate_config_view_ids(args.config):
     if "refresh_token" in args.config:  # if refresh_token in config assume OAuth2 credentials
         args.config['auth_method'] = "oauth2"
         additional_config_keys = ['client_id', 'client_secret', 'refresh_token']

--- a/tap_google_analytics/__init__.py
+++ b/tap_google_analytics/__init__.py
@@ -11,13 +11,13 @@ from .sync import sync_report
 LOGGER = singer.get_logger()
 
 
-# TODO: Unit test this
+# TODO: Add an integration test with multiple profiles that asserts state
 def clean_state_for_report(config, state, tap_stream_id):
-    top_level_bookmark = utils.strptime_to_utc(get_bookmark(state,
-                                                            tap_stream_id,
-                                                            'last_report_date',
-                                                            default=config['start_date']))
+    top_level_bookmark = get_bookmark(state,
+                                      tap_stream_id,
+                                      'last_report_date')
     if top_level_bookmark:
+        top_level_bookmark = utils.strptime_to_utc(top_level_bookmark)
         LOGGER.info("%s - Converting state to multi-profile format.", tap_stream_id)
         view_ids = get_view_ids(config)
         for view_id in view_ids:

--- a/tap_google_analytics/__init__.py
+++ b/tap_google_analytics/__init__.py
@@ -24,7 +24,7 @@ def clean_state_for_report(config, state, tap_stream_id):
             state = singer.write_bookmark(state,
                                           tap_stream_id,
                                           view_id,
-                                          {'last_report_date': report_date.strftime("%Y-%m-%d")})
+                                          {'last_report_date': top_level_bookmark.strftime("%Y-%m-%d")})
         state = singer.clear_bookmark(state, tap_stream_id, 'last_report_date')
         singer.write_state(state)
     return state
@@ -102,7 +102,7 @@ def do_sync(client, config, catalog, state):
         schema = stream.schema.to_dict()
 
         singer.write_schema(
-            report['name'],
+            stream.stream,
             schema,
             stream.key_properties
             )
@@ -133,7 +133,7 @@ def validate_config_view_ids(config):
 def main():
     required_config_keys = ['start_date']
     args = singer.parse_args(required_config_keys)
-    validate_config_view_ids(args.config):
+    validate_config_view_ids(args.config)
     if "refresh_token" in args.config:  # if refresh_token in config assume OAuth2 credentials
         args.config['auth_method'] = "oauth2"
         additional_config_keys = ['client_id', 'client_secret', 'refresh_token']

--- a/tap_google_analytics/client.py
+++ b/tap_google_analytics/client.py
@@ -106,7 +106,7 @@ class Client():
 
     @backoff.on_exception(backoff.expo,
                           (requests.exceptions.RequestException),
-                          max_tries=6,
+                          max_tries=10,
                           giveup=should_giveup,
                           factor=4,
                           jitter=None)

--- a/tap_google_analytics/client.py
+++ b/tap_google_analytics/client.py
@@ -248,10 +248,13 @@ class Client():
         """
         nextPageToken = None
         # TODO: Optimization, if speed is an issue, up to 5 requests can be placed per HTTP batch
-        # - This will require changes to all parsing code
+        # - This will require changes to all parsing code to account for multiple report responses coming back
         while True:
             report_date_string = report_date.strftime("%Y-%m-%d")
-            LOGGER.info("Making report request for %s (nextPageToken: %s)", report_date_string, nextPageToken)
+            LOGGER.info("Making report request for profile ID %s and date %s (nextPageToken: %s)",
+                        profile_id,
+                        report_date_string,
+                        nextPageToken)
             body = {"reportRequests":
                     [{"viewId": profile_id,
                       "dateRanges": [{"startDate": report_date_string,

--- a/tap_google_analytics/discover.py
+++ b/tap_google_analytics/discover.py
@@ -62,6 +62,9 @@ def type_to_schema(ga_type, field_id):
     else:
         raise Exception("Unknown Google Analytics type: {}".format(ga_type))
 
+def types_to_schema(ga_types, field_id):
+    return {"anyOf": [type_to_schema(t, field_id) for t in set(ga_types)]}
+
 def is_static_XX_field(field_id, cubes_lookup):
     """
     GA has fields that are documented using a placeholder of `XX`, where
@@ -126,18 +129,21 @@ goal_related_field_ids = ['ga:goalXXStarts',
                           'ga:goalXXAbandonRate',
                           'ga:searchGoalXXConversionRate']
 
-def get_dynamic_field_names(client, field, profile_id):
+def get_dynamic_fields_named(client, field, profile_id):
     """
     For known field types, retrieve their numeric forms through the client
     on a case-by-case basis (e.g., goals)
     """
     if field['id'] in goal_related_field_ids:
-        return [field['id'].replace('XX', str(i)) for i in client.get_goals_for_profile(profile_id)]
+        return [{**field,
+                 "id": field['id'].replace('XX', str(i)),
+                 "profiles": [profile_id]}
+                for i in client.get_goals_for_profile(profile_id)]
     else:
         # Skip unknown, or already handled, dynamic fields
         return []
 
-def handle_dynamic_XX_field(client, field, cubes_lookup, profile_id):
+def handle_dynamic_XX_field(client, field, cubes_lookup, profile_ids):
     """
     Discovers dynamic names of a given XX field using `client` with
     `get_dynamic_field_names` and matches them with the cubes known
@@ -148,18 +154,35 @@ def handle_dynamic_XX_field(client, field, cubes_lookup, profile_id):
     - Sub Schemas  {"<numeric_field_id>": {...field schema}, ...}
     - Sub Metadata {"numeric_field_id>": {...cubes metadata value}, ...}
     """
-    dynamic_field_names = get_dynamic_field_names(client, field, profile_id)
+    # Do the logic of all profiles
+    dynamic_field_names_per_profile = {}
+    for profile_id in profile_ids:
+        dynamic_field_names_per_profile[profile_id] = get_dynamic_fields_named(client, field, profile_id)
 
-    sub_schemas = {d: type_to_schema(field["dataType"],field["id"])
-                   for d in dynamic_field_names}
+    dynamic_superfields = get_custom_fields_supertypes(dynamic_field_names_per_profile)
 
-    sub_metadata = {r: cubes_lookup[field['id']]
-                    for r in dynamic_field_names}
-    return sub_schemas, sub_metadata
+    sub_schemas = {d['id']: types_to_schema(d["dataTypes"], field["id"])
+                   for d in dynamic_superfields}
 
-def write_metadata(mdata, field, cubes):
+    sub_metadata = {r['id']: cubes_lookup[field['id']]
+                    for r in dynamic_superfields}
+
+    dynamic_fields_support = calculate_custom_fields_support(dynamic_field_names_per_profile)
+
+    return sub_schemas, sub_metadata, dynamic_fields_support
+
+def write_metadata(mdata, field, cubes, custom_fields_support=None):
     """ Translate a field_info object and its cubes into its metadata, and write it. """
-    mdata = metadata.write(mdata, ("properties", field["id"]), "inclusion", "available")
+    unsupported_profiles = (custom_fields_support or {}).get(field['id'])
+    if custom_fields_support is None or not unsupported_profiles:
+        mdata = metadata.write(mdata, ("properties", field["id"]), "inclusion", "available")
+    else:
+        mdata = metadata.write(mdata, ("properties", field["id"]), "inclusion", "unsupported")
+        mdata = metadata.write(mdata,
+                               ("properties", field["id"]),
+                               "unsupported-description",
+                               "This field cannot be selected because it is not defined in profile(s): {}".format(
+                                   ', '.join(unsupported_profiles)))
     mdata = metadata.write(mdata, ("properties", field["id"]), "tap_google_analytics.cubes", list(cubes))
     mdata = metadata.write(mdata, ("properties", field["id"]), "behavior", field["type"])
     mdata = metadata.write(mdata, ("properties", field["id"]), "tap_google_analytics.group", field["group"])
@@ -188,7 +211,44 @@ def generate_base_metadata(all_cubes, schema):
                    mdata)
     return mdata
 
-def generate_catalog_entry(client, standard_fields, custom_fields, all_cubes, cubes_lookup, profile_id):
+def calculate_custom_fields_support(custom_fields):
+    """
+    Return a dictionary of `{field_id: set(profiles_that_don't_support_it)}`.
+    `custom_fields` should be of the form: {profile_id: [field_definition, ...], ...}
+    """
+    all_profiles = set(custom_fields.keys())
+    custom_fields_sets = {}
+    for fields in custom_fields.values():
+        for field in fields:
+            custom_fields_sets[field['id']] = (custom_fields_sets.get(field['id'], all_profiles) -
+                                               set(field['profiles']))
+
+    return custom_fields_sets
+
+def get_custom_fields_supertypes(custom_fields):
+    """
+    Returns a list of fields with their aggregate things.
+    E.g., [{
+        "id": "ga:metric1",
+        "kind": "analytics#customMetric",
+        "dataTypes": ["string", "currency", ...],
+        "type": "METRIC",
+        "group": "Custom Fields"
+    }, ...]
+    """
+    super_fields = {}
+    for fields in custom_fields.values():
+        for field in fields:
+            super_field = super_fields.get(field['id'], {"id": field["id"],
+                                                         "kind": field.get("kind"),
+                                                         "dataTypes": set(),
+                                                         "type": field["type"],
+                                                         "group": field["group"]})
+            super_field['dataTypes'].add(field['dataType'])
+            super_fields[field['id']] = super_field
+    return list(super_fields.values())
+
+def generate_catalog_entry(client, standard_fields, custom_fields, all_cubes, cubes_lookup, profile_ids):
     schema = generate_base_schema()
     mdata = generate_base_metadata(all_cubes, schema)
 
@@ -203,17 +263,24 @@ def generate_catalog_entry(client, standard_fields, custom_fields, all_cubes, cu
                 specific_field = {**standard_field, **{"id": calculated_id}}
                 mdata = write_metadata(mdata, specific_field, cubes)
         elif is_dynamic_XX_field(standard_field["id"], cubes_lookup):
-            sub_schemas, sub_mdata = handle_dynamic_XX_field(client, standard_field, cubes_lookup, profile_id)
+            sub_schemas, sub_mdata, dynamic_fields_support = handle_dynamic_XX_field(client,
+                                                                                     standard_field,
+                                                                                     cubes_lookup,
+                                                                                     profile_ids)
             schema["properties"].update(sub_schemas)
             for calculated_id, cubes in sub_mdata.items():
                 specific_field = {**standard_field, **{"id": calculated_id}}
-                mdata = write_metadata(mdata, specific_field, cubes)
+                mdata = write_metadata(mdata, specific_field, cubes, dynamic_fields_support)
         else:
             schema["properties"][standard_field["id"]] = type_to_schema(standard_field["dataType"],
                                                                         standard_field["id"])
-            mdata = write_metadata(mdata, standard_field, cubes_lookup[standard_field["id"]])
+            mdata = write_metadata(mdata,
+                                   standard_field,
+                                   cubes_lookup[standard_field["id"]])
 
-    for custom_field in custom_fields:
+    custom_fields_support = calculate_custom_fields_support(custom_fields)
+    custom_super_fields = get_custom_fields_supertypes(custom_fields)
+    for custom_field in custom_super_fields:
         if custom_field["kind"] == 'analytics#customDimension':
             cubes_lookup_name = 'ga:dimensionXX'
         elif custom_field["kind"] == 'analytics#customMetric':
@@ -223,8 +290,8 @@ def generate_catalog_entry(client, standard_fields, custom_fields, all_cubes, cu
 
         cubes = cubes_lookup[cubes_lookup_name]
 
-        mdata = write_metadata(mdata, custom_field, cubes)
-        schema["properties"][custom_field["id"]] = type_to_schema(custom_field["dataType"],
+        mdata = write_metadata(mdata, custom_field, cubes, custom_fields_support)
+        schema["properties"][custom_field["id"]] = types_to_schema(custom_field["dataTypes"],
                                                                   custom_field["id"])
 
     return schema, mdata
@@ -320,7 +387,7 @@ def get_standard_fields(client):
     unsupported_fields = {"ga:customVarValueXX", "ga:customVarNameXX", "ga:calcMetric_<NAME>"}
     return [transform_field(f) for f in metadata_response["items"] if f["id"] not in unsupported_fields]
 
-def generate_catalog(client, report_config, standard_fields, custom_fields, all_cubes, cubes_lookup, profile_id):
+def generate_catalog(client, report_config, standard_fields, custom_fields, all_cubes, cubes_lookup, profile_ids):
     """
     Generate a catalog entry for each report specified in `report_config`
     """
@@ -346,14 +413,13 @@ def generate_catalog(client, report_config, standard_fields, custom_fields, all_
                                             tap_stream_id=report['name'],
                                             metadata=metadata.to_list(mdata)))
 
-
     for report in report_config:
         schema, mdata = generate_catalog_entry(client,
                                                standard_fields,
                                                custom_fields,
                                                all_cubes,
                                                cubes_lookup,
-                                               profile_id)
+                                               profile_ids)
 
         catalog_entries.append(CatalogEntry(schema=Schema.from_dict(schema),
                                             key_properties=['_sdc_record_hash'],
@@ -362,15 +428,17 @@ def generate_catalog(client, report_config, standard_fields, custom_fields, all_
                                             metadata=metadata.to_list(mdata)))
     return Catalog(catalog_entries)
 
-def discover(client, config, profile_id):
+def discover(client, config, profile_ids):
     # Draw from spike to discover all the things
     # Get field_infos (standard and custom)
     report_config = config.get("report_definitions") or []
     LOGGER.info("Discovering standard fields...")
     standard_fields = get_standard_fields(client)
     LOGGER.info("Discovering custom fields...")
-    custom_fields = get_custom_fields(client, profile_id)
+    custom_fields = {}
+    for profile_id in profile_ids:
+        custom_fields[profile_id] = get_custom_fields(client, profile_id)
     LOGGER.info("Parsing cube definitions...")
     all_cubes, cubes_lookup = parse_cube_definitions(client)
     LOGGER.info("Generating catalog...")
-    return generate_catalog(client, report_config, standard_fields, custom_fields, all_cubes, cubes_lookup, profile_id)
+    return generate_catalog(client, report_config, standard_fields, custom_fields, all_cubes, cubes_lookup, profile_ids)

--- a/tap_google_analytics/sync.py
+++ b/tap_google_analytics/sync.py
@@ -119,8 +119,8 @@ def sync_report(client, schema, report, start_date, end_date, state):
                 if all_data_golden:
                     singer.write_bookmark(state,
                                           report["id"],
-                                          "last_report_date",
-                                          report_date.strftime("%Y-%m-%d"))
+                                          report['profile_id'],
+                                          {'last_report_date': report_date.strftime("%Y-%m-%d")})
                     singer.write_state(state)
                     if not is_data_golden:
                         # Stop bookmarking on first "isDataGolden": False

--- a/tests/unittests/test_discovery_utilities.py
+++ b/tests/unittests/test_discovery_utilities.py
@@ -1,0 +1,213 @@
+import datetime
+import pytz
+import unittest
+from unittest.mock import Mock, MagicMock, patch
+
+from tap_google_analytics.discover import calculate_custom_fields_support, \
+    get_custom_fields_supertypes, types_to_schema
+
+class TestCalculateCustomFieldsSupport(unittest.TestCase):
+
+    def test_single_profile_id_full_support(self):
+
+        custom_fields = {
+            '12345': [{'id': 'metric1',
+                       'profiles': ['12345']},
+                      {'id': 'metric2',
+                       'profiles': ['12345']},
+                      {'id': 'dimension1',
+                       'profiles': ['12345']}]
+        }
+
+        actual = calculate_custom_fields_support(custom_fields)
+
+        expected = {
+            'metric1': set(),
+            'metric2': set(),
+            'dimension1': set()
+        }
+
+        self.assertEquals(expected, actual)
+
+    def test_multiple_profiles_same_property_id_full_support(self):
+        custom_fields = {
+            '12345': [{'id': 'metric1',
+                       'profiles': ['12345', '67890']},
+                      {'id': 'metric2',
+                       'profiles': ['12345', '67890']},
+                      {'id': 'dimension1',
+                       'profiles': ['12345', '67890']}],
+            '67890': [{'id': 'metric1',
+                       'profiles': ['12345', '67890']},
+                      {'id': 'metric2',
+                       'profiles': ['12345', '67890']},
+                      {'id': 'dimension1',
+                       'profiles': ['12345', '67890']}]
+        }
+
+        actual = calculate_custom_fields_support(custom_fields)
+
+        expected = {
+            'metric1': set(),
+            'metric2': set(),
+            'dimension1': set()
+        }
+
+        self.assertEquals(expected, actual)
+
+    def test_multiple_profiles_different_property_id_full_support(self):
+        custom_fields = {
+            '12345': [{'id': 'metric1',
+                       'profiles': ['12345']},
+                      {'id': 'metric2',
+                       'profiles': ['12345']},
+                      {'id': 'dimension1',
+                       'profiles': ['12345']}],
+            '67890': [{'id': 'metric1',
+                       'profiles': ['67890']},
+                      {'id': 'metric2',
+                       'profiles': ['67890']},
+                      {'id': 'dimension1',
+                       'profiles': ['67890']}]
+        }
+
+        actual = calculate_custom_fields_support(custom_fields)
+
+        expected = {
+            'metric1': set(),
+            'metric2': set(),
+            'dimension1': set()
+        }
+
+        self.assertEquals(expected, actual)
+
+
+    def test_multiple_profile_id_partial_support(self):
+        custom_fields = {
+            '12345': [{'id': 'metric1',
+                       'profiles': ['12345']},
+                      {'id': 'metric2',
+                       'profiles': ['12345']},
+                      {'id': 'dimension1',
+                       'profiles': ['12345']}],
+            '67890': [{'id': 'metric1',
+                       'profiles': ['67890']},
+                      {'id': 'metric3',
+                       'profiles': ['67890']},
+                      {'id': 'dimension1',
+                       'profiles': ['67890']}]
+        }
+
+        actual = calculate_custom_fields_support(custom_fields)
+
+        expected = {
+            'metric1': set(),
+            'metric2': {'67890'},
+            'metric3': {'12345'},
+            'dimension1': set()
+        }
+
+        self.assertEquals(expected, actual)
+
+class TestGetCustomFieldsSupertypes(unittest.TestCase):
+
+    def test_single_profile_works(self):
+        custom_fields = {
+            '12345': [{'id': 'metric1',
+                       'kind': 'analytics#customMetric',
+                       'dataType': 'STRING',
+                       'type': 'METRIC',
+                       'group': 'Custom Fields'}]
+        }
+
+        actual = get_custom_fields_supertypes(custom_fields)
+
+        expected = [
+            {'id': 'metric1',
+             'kind': 'analytics#customMetric',
+             'dataTypes': {'STRING'},
+             'type': 'METRIC',
+             'group': 'Custom Fields'}
+        ]
+
+        self.assertEqual(expected, actual)
+
+    def test_multiple_profiles_same_datatypes_works(self):
+        custom_fields = {
+            '12345': [{'id': 'metric1',
+                       'kind': 'analytics#customMetric',
+                       'dataType': 'STRING',
+                       'type': 'METRIC',
+                       'group': 'Custom Fields'}],
+            '67890': [{'id': 'metric1',
+                       'kind': 'analytics#customMetric',
+                       'dataType': 'STRING',
+                       'type': 'METRIC',
+                       'group': 'Custom Fields'}]
+        }
+
+        actual = get_custom_fields_supertypes(custom_fields)
+
+        expected = [
+            {'id': 'metric1',
+             'kind': 'analytics#customMetric',
+             'dataTypes': {'STRING'},
+             'type': 'METRIC',
+             'group': 'Custom Fields'}
+        ]
+
+        self.assertEqual(expected, actual)
+
+    def test_multiple_profiles_different_datatypes_works(self):
+        custom_fields = {
+            '12345': [{'id': 'metric1',
+                       'kind': 'analytics#customMetric',
+                       'dataType': 'STRING',
+                       'type': 'METRIC',
+                       'group': 'Custom Fields'}],
+            '67890': [{'id': 'metric1',
+                       'kind': 'analytics#customMetric',
+                       'dataType': 'CURRENCY',
+                       'type': 'METRIC',
+                       'group': 'Custom Fields'}]
+        }
+
+        actual = get_custom_fields_supertypes(custom_fields)
+
+        expected = [
+            {'id': 'metric1',
+             'kind': 'analytics#customMetric',
+             'dataTypes': {'STRING', 'CURRENCY'},
+             'type': 'METRIC',
+             'group': 'Custom Fields'}
+        ]
+
+        self.assertEqual(expected, actual)
+
+class TestTypesToSchema(unittest.TestCase):
+
+    def test_single_type_returns_no_anyof(self):
+        actual = types_to_schema(['FLOAT'], 'ga:testField')
+
+        expected = {'type': ['number', 'null']}
+
+        self.assertEqual(expected, actual)
+
+    def test_multiple_types_no_duplicates_returns_sorted(self):
+        # NB: The order of the input for this one is important.
+        # CURRENCY = number, TIME = string, INTEGER = integer
+        actual = types_to_schema(['CURRENCY', 'TIME', 'INTEGER'], 'ga:testField')
+
+        expected = {'anyOf': [{'type': ['integer', 'null']},
+                              {'type': ['number', 'null']},
+                              {'type': ['string', 'null']}]}
+
+        self.assertEqual(expected, actual)
+
+    def test_multiple_types_with_duplicates_returns_no_duplicates(self):
+        actual = types_to_schema(['CURRENCY', 'PERCENT', 'INTEGER'], 'ga:testField')
+
+        expected = {'anyOf': [{'type': ['integer', 'null']},
+                              {'type': ['number', 'null']}]}
+
+        self.assertEqual(expected, actual)

--- a/tests/unittests/test_state_utilities.py
+++ b/tests/unittests/test_state_utilities.py
@@ -1,0 +1,166 @@
+import datetime
+import pytz
+import unittest
+from unittest.mock import Mock, MagicMock, patch
+
+from tap_google_analytics import clean_state_for_report, get_start_date
+
+class TestCleanStateForReport(unittest.TestCase):
+
+    def test_single_profile_old_state(self):
+        config = {
+            'view_id': '12345',
+            'start_date': '2020-03-15'
+        }
+
+        state = {
+            'bookmarks': {
+                'report1': {
+                    'last_report_date': '2020-04-01'
+                }
+            }
+        }
+
+        actual = clean_state_for_report(config, state, 'report1')
+
+        expected = {
+            'bookmarks': {
+                'report1': {
+                    '12345': {
+                        'last_report_date': '2020-04-01'
+                    }
+                }
+            }
+        }
+        self.assertEqual(expected, actual)
+
+    def test_multiple_profiles_old_state(self):
+        config = {
+            'view_ids': ['12345', '67890'],
+            'start_date': '2020-03-15'
+        }
+
+        state = {
+            'bookmarks': {
+                'report1': {
+                    'last_report_date': '2020-04-01'
+                }
+            }
+        }
+
+        actual = clean_state_for_report(config, state, 'report1')
+
+        expected = {
+            'bookmarks': {
+                'report1': {
+                    '12345': {
+                        'last_report_date': '2020-04-01'
+                    },
+                    '67890': {
+                        'last_report_date': '2020-04-01'
+                    }
+                }
+            }
+        }
+        self.assertEqual(expected, actual)
+
+    def test_converted_state_does_nothing(self):
+        config = {
+            'view_id': '12345',
+            'start_date': '2020-03-15'
+        }
+
+        state = {
+            'bookmarks': {
+                'report1': {
+                    '12345': {
+                        'last_report_date': '2020-04-01'
+                    }
+                }
+            }
+        }
+
+        actual = clean_state_for_report(config, state, 'report1')
+
+        expected = {
+            'bookmarks': {
+                'report1': {
+                    '12345': {
+                        'last_report_date': '2020-04-01'
+                    }
+                }
+            }
+        }
+        self.assertEqual(expected, actual)
+
+    def test_empty_state_does_nothing(self):
+        config = {
+            'view_id': '12345',
+            'start_date': '2020-03-15'
+        }
+
+        state = {}
+
+        actual = clean_state_for_report(config, state, 'report1')
+
+        expected = {}
+
+        self.assertEqual(expected, actual)
+
+class TestGetStartDate(unittest.TestCase):
+
+    def test_new_view_id_returns_start_date(self):
+        config = {'start_date': '2020-03-15'}
+
+        view_id = '67890'
+
+        state = {
+            'bookmarks': {
+                'report1': {
+                    '12345': {
+                        'last_report_date': '2020-04-01'
+                    }
+                }
+            }
+        }
+
+        actual = get_start_date(config, view_id, state, 'report1')
+
+        expected = datetime.datetime(2020, 3, 15, tzinfo=pytz.utc)
+
+        self.assertEqual(expected, actual)
+
+    def test_has_view_id_returns_bookmark(self):
+        config = {'start_date': '2020-03-15'}
+
+        view_id = '12345'
+
+        state = {
+            'bookmarks': {
+                'report1': {
+                    '12345': {
+                        'last_report_date': '2020-04-01'
+                    }
+                }
+            }
+        }
+
+        actual = get_start_date(config, view_id, state, 'report1')
+
+        expected = datetime.datetime(2020, 4, 1, tzinfo=pytz.utc)
+
+        self.assertEqual(expected, actual)
+
+
+    def test_empty_state_returns_start_date(self):
+        config = {'start_date': '2020-03-15'}
+
+        view_id = '12345'
+
+        state = {}
+
+        actual = get_start_date(config, view_id, state, 'report1')
+
+        expected = datetime.datetime(2020, 3, 15, tzinfo=pytz.utc)
+
+        self.assertEqual(expected, actual)

--- a/tests/unittests/test_sync_utilities.py
+++ b/tests/unittests/test_sync_utilities.py
@@ -32,7 +32,7 @@ class TestIsDataGoldenBookmarking(unittest.TestCase):
                     utils.strptime_to_utc("2019-11-04"),
                     state)
         # Ensure we stopped bookmarking at third day
-        self.assertEqual({'bookmarks': {'123': {'last_report_date': '2019-11-03'}}}, state)
+        self.assertEqual({'bookmarks': {'123': {'12345': {'last_report_date': '2019-11-03'}}}}, state)
         # Ensure we paginated through all 4 days, not stopping at third
         self.assertEqual(self.client.get_report.call_count, 4)
 
@@ -47,7 +47,7 @@ class TestIsDataGoldenBookmarking(unittest.TestCase):
                     utils.strptime_to_utc("2019-11-03"),
                     utils.strptime_to_utc("2019-11-03"),
                     state)
-        self.assertEqual({'bookmarks': {'123': {'last_report_date': '2019-11-03'}}}, state)
+        self.assertEqual({'bookmarks': {'123': {'12345': {'last_report_date': '2019-11-03'}}}}, state)
         self.assertEqual(self.client.get_report.call_count, 1)
 
 class TestRecordHashing(unittest.TestCase):


### PR DESCRIPTION
# Description of change
Add the option of specifying multiple "view_ids" in the config. This includes a temporary shim compatibility layer that allows both `view_id` and `view_ids` to be specified.

In the event that multiple profiles are selected, the following will occur:
- State will be translated to be of the structure `bookmarks->report_id->view_id->last_report_date`
- Discovery will discover the intersection of ALL CUSTOM FIELDS across all selected views
    - E.g., `view1` has 5 customMetrics (`ga:metric1` through `ga:metric5`) and `view2` is in a different property with only 3 custom metrics (`ga:metric1` through `ga:metric3`). In this scenario metrics 1 through 5 will be discovered, but `ga:metric4` and `ga:metric5` will be marked `unsupported` since all profiles do not have them defined.
        - This opens up the possibility that custom fields (metrics/dimensions/goals) can be selected with different data types and collection mechanisms if contained in different properties, but in this situation, the tap assumes that the user knows what they're doing rather than blocking custom fields in _every_ report.

# QA steps
 - [x] automated tests passing
 - [x] manual qa steps passing (list below)
    - Running through manual smoke testing as well as writing automated tests for new features where applicable.
 
# Risks
 - Medium, if the compatibility shim doesn't work, this can break current users of the tap.
 
# Rollback steps
 - revert this branch
