### PR TITLE
Remove searchkeyword from behavior overview defaults

### DIFF
--- a/tap_google_analytics/reports.py
+++ b/tap_google_analytics/reports.py
@@ -128,8 +128,7 @@ PREMADE_REPORTS = [
         "default_dimensions": [
             "ga:date",
             "ga:pagePath",
-            "ga:pageTitle",
-            "ga:searchKeyword"
+            "ga:pageTitle"
         ]
     },
     {

--- a/tests/test_google_analytics_basic_sync.py
+++ b/tests/test_google_analytics_basic_sync.py
@@ -77,7 +77,7 @@ class TestGoogleAnalyticsBasicSync(unittest.TestCase):
             "Audience Geo Location": {"ga:users","ga:newUsers","ga:sessions","ga:pageviewsPerSession","ga:avgSessionDuration","ga:bounceRate","ga:date","ga:country","ga:city","ga:continent","ga:subContinent"},
             "Audience Technology": {"ga:users","ga:newUsers","ga:sessions","ga:pageviewsPerSession","ga:avgSessionDuration","ga:bounceRate","ga:date","ga:browser","ga:operatingSystem"},
             "Acquisition Overview": {"ga:sessions","ga:pageviewsPerSession","ga:avgSessionDuration","ga:bounceRate","ga:acquisitionTrafficChannel","ga:acquisitionSource","ga:acquisitionSourceMedium","ga:acquisitionMedium"},
-            "Behavior Overview": {"ga:pageviews","ga:uniquePageviews","ga:avgTimeOnPage","ga:bounceRate","ga:exitRate","ga:exits","ga:date","ga:pagePath","ga:pageTitle","ga:searchKeyword"},
+            "Behavior Overview": {"ga:pageviews","ga:uniquePageviews","ga:avgTimeOnPage","ga:bounceRate","ga:exitRate","ga:exits","ga:date","ga:pagePath","ga:pageTitle"},
             "Ecommerce Overview": {"ga:transactions","ga:transactionId","ga:campaign","ga:source","ga:medium","ga:keyword","ga:socialNetwork"}
         }
 


### PR DESCRIPTION
# Description of change
It seems that searchKeyword isn't something that's collected by default, nor shown on the overview report's dashboard by default, so this PR removes it from the `Behavior Overview` pre-made report definition's default dimensions.

# QA steps
 - [ ] automated tests passing
 - [ ] manual qa steps passing (list below)
    - None, this should be covered by automation
 
# Risks
 - Low, this is removal of a default, it won't affect any catalogs with the field already selected.
 
# Rollback steps
 - revert this branch
