### PR TITLE
Parse datetimes using Google's format

### DIFF
--- a/tap_google_analytics/discover.py
+++ b/tap_google_analytics/discover.py
@@ -27,7 +27,8 @@ integer_field_overrides = {'ga:cohortNthDay',
                            'ga:visitsToTransaction'}
 
 datetime_field_overrides = {'ga:date',
-                            'ga:dateHour'}
+                            'ga:dateHour',
+                            'ga:dateHourMinute'}
 
 float_field_overrides = {'ga:latitude',
                          'ga:longitude',


### PR DESCRIPTION
# Description of change
Correct the datetime parsing behavior for fields in the `Time` group. These come back using non-ISO types, so they were being rejected by the Transformer.

This adds a step before writing the records that will parse them as datetimes and convert them to ISO-8601 format (at UTC timezone).

# QA steps
 - [ ] automated tests passing
 - [X] manual qa steps passing (list below)
   - Ran through a manual sync and inspected the values at each conversion step.
 
# Risks
 - Medium, I'm adding a new field to the datetime types mapping, which could result in mixed datatypes for some users.
 
# Rollback steps
 - revert this branch, bump patch version and re-release
