### PR TITLE
Fix "reason" checking logic for retryable 403s

### DIFF
--- a/tap_google_analytics/client.py
+++ b/tap_google_analytics/client.py
@@ -22,7 +22,7 @@ def is_retryable_403(response):
     https://developers.google.com/analytics/devguides/reporting/metadata/v3/errors
     """
     retryable_errors = {"userRateLimitExceeded", "rateLimitExceeded", "quotaExceeded"}
-    error_reasons = {error.get('reason') for error in response.json().get('errors',[])}
+    error_reasons = {error.get('reason') for error in response.json().get('error', {}).get('errors',[])}
 
     if any(error_reasons.intersection(retryable_errors)):
         return True


### PR DESCRIPTION
# Description of change
Fixes #24 oversight, where the `errors` key is actually below another `error` key in the response's JSON.

# QA steps
 - [x] manual qa steps passing (list below)
    - Unable to reproduce the issue locally, but ran through with an example using this code on the command line directly.
 
# Risks
 - Low, it's safe error handling code.
 
# Rollback steps
 - revert this branch, bump patch version, re-release
