### PR TITLE
Reduce retry frequency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.4.6
+  * Make retries less aggressive to converse quota [#31](https://github.com/singer-io/tap-google-analytics/pull/31)
+
 ## 0.4.5
   * All 4xx errors that are not retryable should show error message [#29](https://github.com/singer-io/tap-google-analytics/pull/29)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 0.4.6
-  * Make retries less aggressive to converse quota [#31](https://github.com/singer-io/tap-google-analytics/pull/31)
+  * Make retries less aggressive to conserve quota [#31](https://github.com/singer-io/tap-google-analytics/pull/31)
 
 ## 0.4.5
   * All 4xx errors that are not retryable should show error message [#29](https://github.com/singer-io/tap-google-analytics/pull/29)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-google-analytics",
-    version="0.4.5",
+    version="0.4.6",
     description="Singer.io tap for extracting data",
     author="Stitch",
     url="http://singer.io",

--- a/tap_google_analytics/client.py
+++ b/tap_google_analytics/client.py
@@ -22,18 +22,7 @@ def is_retryable_403(response):
     https://developers.google.com/analytics/devguides/reporting/metadata/v3/errors
     """
     retryable_errors = {"userRateLimitExceeded", "rateLimitExceeded", "quotaExceeded"}
-    error_reasons = None
-    resp_json = response.json()
-    if isinstance(resp_json, dict):
-        error = resp_json.get('error', {})
-        if isinstance(error, dict):
-            errors = error.get('errors', [])
-            if isinstance(errors, list):
-                error_reasons = {error.get('reason') for error in errors}
-
-    if error_reasons is None:
-        # Unknown error structures should not be retried for now
-        return False
+    error_reasons = {error.get('reason') for error in response.json().get('error', {}).get('errors',[])}
 
     if any(error_reasons.intersection(retryable_errors)):
         return True

--- a/tap_google_analytics/client.py
+++ b/tap_google_analytics/client.py
@@ -136,11 +136,15 @@ class Client():
         self.expires_in = token_json['expires_in']
 
 
+    # For fewer requests, and reliability. This backoff tries less hard.
+    # Backoff Max Time: try 1 (wait 10) 2 (wait 100) 3 (wait 1000) 4
+    # Gives us waits of: (10 * 10 ^ 0), (10 * 10 ^ 1), (10 * 10 ^ 2)
     @backoff.on_exception(backoff.expo,
                           (requests.exceptions.RequestException),
-                          max_tries=10,
+                          max_tries=4,
+                          base=10,
                           giveup=should_giveup,
-                          factor=4,
+                          factor=10,
                           jitter=None)
     def _make_request(self, method, url, params=None, data=None):
         params = params or {}

--- a/tap_google_analytics/client.py
+++ b/tap_google_analytics/client.py
@@ -22,7 +22,18 @@ def is_retryable_403(response):
     https://developers.google.com/analytics/devguides/reporting/metadata/v3/errors
     """
     retryable_errors = {"userRateLimitExceeded", "rateLimitExceeded", "quotaExceeded"}
-    error_reasons = {error.get('reason') for error in response.json().get('error', {}).get('errors',[])}
+    error_reasons = None
+    resp_json = response.json()
+    if isinstance(resp_json, dict):
+        error = resp_json.get('error', {})
+        if isinstance(error, dict):
+            errors = error.get('errors', [])
+            if isinstance(errors, list):
+                error_reasons = {error.get('reason') for error in errors}
+
+    if error_reasons is None:
+        # Unknown error structures should not be retried for now
+        return False
 
     if any(error_reasons.intersection(retryable_errors)):
         return True

--- a/tests/test_google_analytics_basic_sync.py
+++ b/tests/test_google_analytics_basic_sync.py
@@ -84,6 +84,7 @@ class TestGoogleAnalyticsBasicSync(unittest.TestCase):
     def get_properties(self):
         return {
             'start_date' : '2020-03-01T00:00:00Z',
+            'end_date' : '2020-04-01T00:00:00Z',
             'view_id': os.getenv('TAP_GOOGLE_ANALYTICS_VIEW_ID'),
             'report_definitions': [{"id": "a665732c-d18b-445c-89b2-5ca8928a7305", "name": "report 1"}]
         }

--- a/tests/test_google_analytics_basic_sync.py
+++ b/tests/test_google_analytics_basic_sync.py
@@ -3,6 +3,8 @@ import tap_tester.menagerie   as menagerie
 import tap_tester.runner      as runner
 import os
 import unittest
+from datetime import timedelta
+from singer import utils
 from functools import reduce
 
 class TestGoogleAnalyticsBasicSync(unittest.TestCase):
@@ -83,8 +85,7 @@ class TestGoogleAnalyticsBasicSync(unittest.TestCase):
 
     def get_properties(self):
         return {
-            'start_date' : '2020-03-01T00:00:00Z',
-            'end_date' : '2020-04-01T00:00:00Z',
+            'start_date' : (utils.now() - timedelta(days=30)).strftime('%Y-%m-%dT00:00:00Z'),
             'view_id': os.getenv('TAP_GOOGLE_ANALYTICS_VIEW_ID'),
             'report_definitions': [{"id": "a665732c-d18b-445c-89b2-5ca8928a7305", "name": "report 1"}]
         }


### PR DESCRIPTION
# Description of change
This tap aggressively retries for retryable errors, and it usually makes it through ~3 or 4 requests before getting back on track. This PR makes it less eager to conserve daily quotas.

# QA steps
 - [X] manual qa steps passing (list below)
    - None, if the tests pass, it will be enough to cover this.
 
# Risks
 - Low
 
# Rollback steps
 - revert this branch and release new patch version
