### PR TITLE
Fix/management quota usage

### DIFF
--- a/tap_google_analytics/client.py
+++ b/tap_google_analytics/client.py
@@ -90,13 +90,6 @@ class Client():
         self.__populate_profile_lookup()
 
     def __transform_account_summaries_to_profile_lookup(self):
-        account_summaries = self.get_account_summaries_for_token()
-        new_lookup = {}
-        for account in account_summaries:
-            for web_property in account.get('webProperties', []):
-                for profile in web_property.get('profiles', []):
-                    new_lookup[profile['id']] = {"web_property_id": web_property['id'],
-                                                 "account_id": account['id']}
         return new_lookup
 
     def __populate_profile_lookup(self):
@@ -104,11 +97,12 @@ class Client():
         Get all profiles available and associate them with their web property
         and account IDs to be looked up later during discovery.
         """
-        for account_id in self.get_accounts_for_token():
-            for web_property_id in self.get_web_properties_for_account(account_id):
-                for profile_id in self.get_profiles_for_property(account_id, web_property_id):
-                    self.profile_lookup[profile_id] = {"web_property_id": web_property_id,
-                                                       "account_id": account_id}
+        account_summaries = self.get_account_summaries_for_token()
+        for account in account_summaries:
+            for web_property in account.get('webProperties', []):
+                for profile in web_property.get('profiles', []):
+                    self.profile_lookup[profile['id']] = {"web_property_id": web_property['id'],
+                                                          "account_id": account['id']}
 
     # Authentication and refresh
     def _ensure_access_token(self):

--- a/tap_google_analytics/client.py
+++ b/tap_google_analytics/client.py
@@ -89,9 +89,6 @@ class Client():
         self.profile_lookup = {}
         self.__populate_profile_lookup()
 
-    def __transform_account_summaries_to_profile_lookup(self):
-        return new_lookup
-
     def __populate_profile_lookup(self):
         """
         Get all profiles available and associate them with their web property

--- a/tap_google_analytics/client.py
+++ b/tap_google_analytics/client.py
@@ -89,6 +89,16 @@ class Client():
         self.profile_lookup = {}
         self.__populate_profile_lookup()
 
+    def __transform_account_summaries_to_profile_lookup(self):
+        account_summaries = self.get_account_summaries_for_token()
+        new_lookup = {}
+        for account in account_summaries:
+            for web_property in account.get('webProperties', []):
+                for profile in web_property.get('profiles', []):
+                    new_lookup[profile['id']] = {"web_property_id": web_property['id'],
+                                                 "account_id": account['id']}
+        return new_lookup
+
     def __populate_profile_lookup(self):
         """
         Get all profiles available and associate them with their web property
@@ -195,6 +205,14 @@ class Client():
             with open(local_cubes_path, "r") as f:
                 cubes_json = json.load(f)
         return cubes_json
+
+    def get_account_summaries_for_token(self):
+        """
+        Return a list of accountSummaries (full account hierarchy that token
+        user has access to) to discover Goals and custom metrics/dimensions.
+        """
+        account_summaries_response = self.get('https://www.googleapis.com/analytics/v3/management/accountSummaries')
+        return account_summaries_response.json()['items']
 
     def get_accounts_for_token(self):
         """ Return a list of account IDs available to hte associated token. """


### PR DESCRIPTION
# Description of change
The tap is currently making (Accounts * WebProperties * Profiles) requests to build the hierarchy of the profiles associated with the token. This PR changes it to use [accountSummaries](https://developers.google.com/analytics/devguides/config/mgmt/v3/mgmtReference/management/accountSummaries/list) which provides only the hierarchical data, and reducing the queries needed to 1.

The tap may need to cache these values in the future (e.g., using state) if this reduction is still not enough for quota usage.

# QA steps
 - [x] automated tests passing
 - [x] manual qa steps passing (list below)
    - Ran through this and confirmed the structure of the resulting lookup object matches the original code.
 
# Risks
 - Low, it's a transformation to a defined map structure, and I've confirmed that the structure matches.
 
# Rollback steps
 - revert this branch
