### PR TITLE
Update bookmarking

### DIFF
--- a/tap_google_analytics/sync.py
+++ b/tap_google_analytics/sync.py
@@ -142,7 +142,7 @@ def sync_report(client, schema, report, start_date, end_date, state, historicall
                                           report['profile_id'],
                                           {'last_report_date': report_date.strftime("%Y-%m-%d")})
                     singer.write_state(state)
-                    if not is_data_golden:
+                    if not is_data_golden and not historically_syncing:
                         # Stop bookmarking on first "isDataGolden": False
                         all_data_golden = False
                 else:

--- a/tap_google_analytics/sync.py
+++ b/tap_google_analytics/sync.py
@@ -136,7 +136,7 @@ def sync_report(client, schema, report, start_date, end_date, state, historicall
                     historically_syncing = not is_data_golden
 
                 # The assumption here is that today's data cannot be golden if yesterday's is also not golden
-                if all_data_golden or historically_syncing:
+                if all_data_golden and not historically_syncing:
                     singer.write_bookmark(state,
                                           report["id"],
                                           report['profile_id'],

--- a/tap_google_analytics/sync.py
+++ b/tap_google_analytics/sync.py
@@ -107,7 +107,6 @@ def sync_report(client, schema, report, start_date, end_date, state):
               "dimensions": dimensions}
     """
     LOGGER.info("Syncing %s for view_id %s", report['name'], report['profile_id'])
-    all_data_golden = True
     # TODO: Is it better to query by multiple days if `ga:date` is present?
     # - If so, we can optimize the calls here to generate date ranges and reduce request volume
     for report_date in generate_report_dates(start_date, end_date):
@@ -130,14 +129,13 @@ def sync_report(client, schema, report, start_date, end_date, state):
                 # - "golden" refers to data that will not change in future
                 #   requests, so we can use it as a bookmark
                 is_data_golden = raw_report_response["reports"][0]["data"].get("isDataGolden")
-
-                if all_data_golden:
+                # The assumption here is that today's data cannot be golden if yesterday's is also not golden
+                if is_data_golden:
                     singer.write_bookmark(state,
                                           report["id"],
                                           report['profile_id'],
                                           {'last_report_date': report_date.strftime("%Y-%m-%d")})
                     singer.write_state(state)
-                    if not is_data_golden:
-                        # Stop bookmarking on first "isDataGolden": False
-                        all_data_golden = False
+                else:
+                    LOGGER.info("Did not detect that data was golden. Skipping writing bookmark.")
     LOGGER.info("Done syncing %s for view_id %s", report['name'], report['profile_id'])

--- a/tests/unittests/test_state_utilities.py
+++ b/tests/unittests/test_state_utilities.py
@@ -126,7 +126,7 @@ class TestGetStartDate(unittest.TestCase):
 
         actual = get_start_date(config, view_id, state, 'report1')
 
-        expected = datetime.datetime(2020, 3, 15, tzinfo=pytz.utc)
+        expected = (True, datetime.datetime(2020, 3, 15, tzinfo=pytz.utc))
 
         self.assertEqual(expected, actual)
 
@@ -147,7 +147,7 @@ class TestGetStartDate(unittest.TestCase):
 
         actual = get_start_date(config, view_id, state, 'report1')
 
-        expected = datetime.datetime(2020, 4, 1, tzinfo=pytz.utc)
+        expected = (False, datetime.datetime(2020, 4, 1, tzinfo=pytz.utc))
 
         self.assertEqual(expected, actual)
 
@@ -161,6 +161,6 @@ class TestGetStartDate(unittest.TestCase):
 
         actual = get_start_date(config, view_id, state, 'report1')
 
-        expected = datetime.datetime(2020, 3, 15, tzinfo=pytz.utc)
+        expected = (True, datetime.datetime(2020, 3, 15, tzinfo=pytz.utc))
 
         self.assertEqual(expected, actual)

--- a/tests/unittests/test_sync_utilities.py
+++ b/tests/unittests/test_sync_utilities.py
@@ -100,7 +100,7 @@ class TestIsDataGoldenBookmarking(unittest.TestCase):
     @patch("tap_google_analytics.sync.report_to_records")
     @patch("singer.write_record")
     @patch("singer.write_state")
-    def test_historical_sync_interrupted_writes_bookmarks(self, *args):
+    def test_historical_sync_interrupted_does_not_write_bookmarks(self, *args):
         # We have observed that if there's no historical data, Google will
         # return a null isDataGolden field. This caused the tap to never
         # save properties. If a tap is interrupted during this time of null
@@ -125,7 +125,7 @@ class TestIsDataGoldenBookmarking(unittest.TestCase):
                         utils.strptime_to_utc("2019-11-02"),
                         state,
                         historically_syncing=True)
-        self.assertEqual({'bookmarks': {'123': {'12345': {'last_report_date': '2019-11-01'}}}}, state)
+        self.assertEqual({}, state)
         self.assertEqual(self.client.get_report.call_count, 4)
 
 

--- a/tests/unittests/test_sync_utilities.py
+++ b/tests/unittests/test_sync_utilities.py
@@ -5,9 +5,16 @@ from singer import utils
 import tap_google_analytics.sync
 from tap_google_analytics.sync import sync_report, generate_sdc_record_hash
 
+# Test State Tracking Globals
 reports = None
+error_after = None
+reports_synced = 0
 
 def get_mock_report(name, profile_id, report_date, metrics, dimensions):
+    global reports_synced
+    if error_after and reports_synced == error_after:
+        raise Exception("Report failed!")
+    reports_synced += 1
     return reports[report_date]
 
 class TestIsDataGoldenBookmarking(unittest.TestCase):
@@ -23,8 +30,13 @@ class TestIsDataGoldenBookmarking(unittest.TestCase):
         self.client.get_report = MagicMock(side_effect=get_mock_report)
 
     def tearDown(self):
+        # Reset globals
         global reports
+        global error_after
+        global reports_synced
         reports = None
+        error_after = None
+        reports_synced = 0
 
     @patch("tap_google_analytics.sync.report_to_records")
     @patch("singer.write_record")
@@ -60,11 +72,19 @@ class TestIsDataGoldenBookmarking(unittest.TestCase):
     @patch("singer.write_record")
     @patch("singer.write_state")
     def test_historical_sync_writes_bookmarks_and_stops_at_first_non_golden(self, *args):
+        # We have observed that if there's no historical data, Google will
+        # return a null isDataGolden field. This caused the tap to never
+        # save properties.
+
+        # Expectation: Full end to end historical sync should function as above.
         global reports
         reports = {
-            utils.strptime_to_utc("2019-10-30"): [{"reports": [{"data": {"isDataGolden": True}}]}],
-            utils.strptime_to_utc("2019-10-31"): [{"reports": [{"data": {"isDataGolden": True}}]}],
-            **reports
+            utils.strptime_to_utc("2019-10-30"): [{"reports": [{"data": {}}]}],
+            utils.strptime_to_utc("2019-10-31"): [{"reports": [{"data": {}}]}],
+            utils.strptime_to_utc("2019-11-01"): [{"reports": [{"data": {"isDataGolden": True}}]}],
+            utils.strptime_to_utc("2019-11-02"): [{"reports": [{"data": {"isDataGolden": True}}]}],
+            utils.strptime_to_utc("2019-11-03"): [{"reports": [{"data": {}}]}],
+            utils.strptime_to_utc("2019-11-04"): [{"reports": [{"data": {"isDataGolden": True}}]}],
         }
         state = {}
         sync_report(self.client,
@@ -76,6 +96,37 @@ class TestIsDataGoldenBookmarking(unittest.TestCase):
                     historically_syncing=True)
         self.assertEqual({'bookmarks': {'123': {'12345': {'last_report_date': '2019-11-03'}}}}, state)
         self.assertEqual(self.client.get_report.call_count, 6)
+
+    @patch("tap_google_analytics.sync.report_to_records")
+    @patch("singer.write_record")
+    @patch("singer.write_state")
+    def test_historical_sync_interrupted_writes_bookmarks(self, *args):
+        # We have observed that if there's no historical data, Google will
+        # return a null isDataGolden field. This caused the tap to never
+        # save properties. If a tap is interrupted during this time of null
+        # golden-ness, it should resume.
+
+        # Expectation: Interrupted historical sync should resume where it left off.
+        global reports
+        global error_after
+        error_after = 3
+        reports = {
+            utils.strptime_to_utc("2019-10-30"): [{"reports": [{"data": {}}]}],
+            utils.strptime_to_utc("2019-10-31"): [{"reports": [{"data": {}}]}],
+            utils.strptime_to_utc("2019-11-01"): [{"reports": [{"data": {}}]}],
+            utils.strptime_to_utc("2019-11-02"): [{"reports": [{"data": {}}]}],
+        }
+        state = {}
+        with self.assertRaises(Exception):
+            sync_report(self.client,
+                        {},
+                        {"id": "123", "name":"test_report", "profile_id": "12345", "metrics":[], "dimensions":[]},
+                        utils.strptime_to_utc("2019-10-30"),
+                        utils.strptime_to_utc("2019-11-02"),
+                        state,
+                        historically_syncing=True)
+        self.assertEqual({'bookmarks': {'123': {'12345': {'last_report_date': '2019-11-01'}}}}, state)
+        self.assertEqual(self.client.get_report.call_count, 4)
 
 
 class TestRecordHashing(unittest.TestCase):


### PR DESCRIPTION
# Description of change
In cases where the `start_date` is set to be far before data actually begins, Google returns a report with 0 rows and a null `isDataGolden` value.

The tap should proceed through these cases for the historical sync (e.g., bookmark matches start_date) and start bookmarking as it normally does once it gets over that block to the first day with golden data.

The most understandable visualization of this situation is when the reports are of this structure, in the new test:

```
        reports = {
            utils.strptime_to_utc("2019-10-30"): [{"reports": [{"data": {}}]}],
            utils.strptime_to_utc("2019-10-31"): [{"reports": [{"data": {}}]}],
            utils.strptime_to_utc("2019-11-01"): [{"reports": [{"data": {"isDataGolden": True}}]}],
            utils.strptime_to_utc("2019-11-02"): [{"reports": [{"data": {"isDataGolden": True}}]}],
            utils.strptime_to_utc("2019-11-03"): [{"reports": [{"data": {}}]}],
            utils.strptime_to_utc("2019-11-04"): [{"reports": [{"data": {"isDataGolden": True}}]}],
        }
```

If a sync is interrupted during historical syncing, it should restart from the beginning the next time, to avoid strange situations where the tap doesn't know it should still be in a historical sync. _**This is to prevent more complicated state management.**_

# QA steps
 - [ ] automated tests passing
 - [X] manual qa steps passing (list below)
    - I workshopped the change iterating on the Unit tests, so all cases tested have been persisted to the unit testing
 
# Risks
 - Low-ish, we're relying on the unit tests to confirm that the behavior still upholds the previous assertions, and added new ones to cover the new cases.
 
# Rollback steps
 - revert this branch and bump patch version
