### PR TITLE
Grabs error reason from 'reason', 'error_description', or falls back to full json response to ensure a good error message

### DIFF
--- a/tap_google_analytics/client.py
+++ b/tap_google_analytics/client.py
@@ -40,7 +40,7 @@ def get_error_reasons(response):
     error_reasons = set()
     if 'error' in response_json:
         error = response_json.get('error')
-        if 'errors' in error:
+        if isinstance(error, dict) and 'errors' in error:
             errors = error.get('errors')
             for sub_error in errors:
                 if 'reason' in sub_error:
@@ -49,14 +49,17 @@ def get_error_reasons(response):
                     error_reasons.add(sub_error.get('error_description'))
                 else:
                     error_reasons.add('reason or error_description missing from error, see full response {}'.format(response_json))
-        elif 'reason' in response:
-            error_reasons.add(response.get('reason'))
-        elif 'error_description' in response:
-            error_reasons.add(response.get('error_description'))
+        elif 'reason' in response_json:
+            error_reasons.add(response_json.get('reason'))
+        elif 'error_description' in response_json:
+            error_reasons.add(response_json.get('error_description'))
+        elif isinstance(error, str):
+            error_reasons.add(error)
         else:
             error_reasons.add('reason or error_description missing from error, see full response {}'.format(response_json))
 
     return error_reasons
+
 
 def should_giveup(e):
     """


### PR DESCRIPTION
# Description of change
https://stitchdata.atlassian.net/browse/SUP-2052

Error response was actually this:
```
pp response.json()
{'error': 'invalid_grant', 'error_description': 'Bad Request'}
```
And not how it's documented in the v3 error response example online: https://developers.google.com/analytics/devguides/config/mgmt/v3/errors?hl=en
```
{
 "error": {
  "errors": [
   {
    "domain": "global",
    "reason": "invalidParameter",
    "message": "Invalid value '-1' for max-results. Value must be within the range: [1, 1000]",
    "locationType": "parameter",
    "location": "max-results"
   }
  ],
  "code": 400,
  "message": "Invalid value '-1' for max-results. Value must be within the range: [1, 1000]"
 }
}
```

# QA steps
 - [x] automated tests passing - will check after PR appears
 - [x] manual qa steps passing (list below)
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
