### PR TITLE
Set on_giveup in backoff to reraise Exception

### DIFF
--- a/tap_google_analytics/client.py
+++ b/tap_google_analytics/client.py
@@ -205,6 +205,10 @@ class Client():
         self.__access_token = token_json['access_token']
         self.expires_in = token_json['expires_in']
 
+    # by default, program should re-raise exceptions on giveup,
+    # or else program ends with code 0 when it failed
+    def on_giveup_handler(details):
+        raise Exception(f"Gave up! Details: {details}")
 
     # For fewer requests, and reliability. This backoff tries less hard.
     # Backoff Max Time: try 1 (wait 10) 2 (wait 100) 3 (wait 1000) 4
@@ -214,6 +218,7 @@ class Client():
                           max_tries=4,
                           base=10,
                           giveup=should_giveup,
+                          on_giveup=on_giveup_handler,
                           factor=10,
                           jitter=None)
     def _make_request(self, method, url, params=None, data=None):


### PR DESCRIPTION
# Description of change
Same as https://github.com/singer-io/tap-facebook/pull/117

Calling CLI tap-google-analytics returns exit code 0 even when it fails
 
# Risks
 - programs that once relied on tap-google-analytics not to return exit code 1 can now fail.
 
# Rollback steps
 - revert this branch
