### PR TITLE
Properly retry on 503 and add unit tests for all status codes that should retry under all conditions

### DIFF
--- a/tap_google_analytics/client.py
+++ b/tap_google_analytics/client.py
@@ -85,7 +85,15 @@ def should_giveup(e):
     return not do_retry
 
 def should_retry(response):
-    return response.status_code == 429 or is_retryable_403(response)
+    """
+    Ensure certain status code responses trigger retries
+    See documentation at https://developers.google.com/analytics/devguides/reporting/core/v4/errors
+    """
+    google_response_status_title = response.json().get("error", {}).get("status")
+
+    return (response.status_code == 429 or
+            is_retryable_403(response) or
+            (response.status_code == 503 and google_response_status_title is not None and google_response_status_title == 'UNAVAILABLE'))
 
 def _is_json(response):
     try:

--- a/tests/unittests/test_client_utilities.py
+++ b/tests/unittests/test_client_utilities.py
@@ -1,6 +1,7 @@
 import unittest
 import requests
-from unittest.mock import Mock, MagicMock, patch
+import re
+from unittest.mock import patch
 
 from tap_google_analytics.client import Client
 
@@ -11,6 +12,9 @@ class MockResponse:
         self.status_code = status_code
 
     def json(self):
+        if self.json_data is None:
+            raise Exception("json data missing")
+
         return self.json_data
 
     def raise_for_status(self):
@@ -22,84 +26,31 @@ class MockResponse:
 def mocked_post_with_self(self, url, headers=None, params=None, json=None):
     return mocked_post(url, headers=headers, params=params, json=json)
 
+URL_PATTERN = re.compile(r'^(?P<status_code>\d+)-(?P<status_title>[A-Z_]+)$')
 def mocked_post(url, headers=None, params=None, json=None, data=None):
-    if url == "429-RESOURCE_EXHAUSTED":
-        return MockResponse(
-            {
-                "error": {
-                    "code": 429,
-                    "message": "error message",
-                    "status": "RESOURCE_EXHAUSTED"
-                }
-            },
-            429)
-    elif url == "400-INVALID_ARGUMENT":
-        return MockResponse(
-            {
-                "error": {
-                    "code": 400,
-                    "message": "error message",
-                    "status": "INVALID_ARGUMENT"
-                }
-            },
-            400)
-    elif url == "401-UNAUTHENTICATED":
-        return MockResponse(
-            {
-                "error": {
-                    "code": 401,
-                    "message": "error message",
-                    "status": "UNAUTHENTICATED"
-                }
-            },
-            401)
-    elif url == "403-PERMISSION_DENIED":
-        return MockResponse(
-            {
-                "error": {
-                    "code": 403,
-                    "message": "error message",
-                    "status": "PERMISSION_DENIED"
-                }
-            },
-            403)
-    elif url == "503-UNAVAILABLE":
-        return MockResponse(
-            {
-                "error": {
-                    "code": 503,
-                    "message": "error message",
-                    "status": "UNAVAILABLE"
-                }
-            },
-            503)
-    elif url == "503-BACKENDERROR":
-        return MockResponse(
-            {
-                "error": {
-                    "code": 503,
-                    "message": "error message",
-                    "status": "BACKEND_ERROR"
-                }
-            },
-            503)
-    elif url == "500-INTERNAL":
-        return MockResponse(
-            {
-                "error": {
-                    "code": 500,
-                    "message": "error message",
-                    "status": "INTERNAL"
-                }
-            },
-            500)
-    elif url == "https://oauth2.googleapis.com/token":
+    if url == "https://oauth2.googleapis.com/token":
         return MockResponse(
             {
                 "access_token": "access_token",
                 "expires_in": 9999999999,
             },
             200)
+    elif url == "NoJsonData":
+        return MockResponse(None, 401)
+
+    matches = URL_PATTERN.match(url)
+    if matches:
+        status_code = int(matches.group("status_code"))
+        status_title = matches.group("status_title")
+        return MockResponse(
+            {
+                "error": {
+                    "code": status_code,
+                    "message": "error message",
+                    "status": status_title
+                }
+            },
+            status_code)
 
     raise NotImplementedError(
         "Unexpected mocked post called with "
@@ -107,28 +58,22 @@ def mocked_post(url, headers=None, params=None, json=None, data=None):
     )
 
 def mocked_request(self, method, url, headers=None, params=None):
-    if method != 'GET':
-        raise NotImplementedError(
-            "Unexpected mocked get called with "
-            "[url={}][headers={}][params={}]".format(url, headers, params)
-        )
-
-    if url == "https://www.googleapis.com/analytics/v3/management/accountSummaries":
-        return MockResponse({
-            'items': []
-        }, 200)
+    if method == 'GET' and url == "https://www.googleapis.com/analytics/v3/management/accountSummaries":
+        return MockResponse(
+            {
+                'items': []
+            },
+            200)
 
     raise NotImplementedError(
         "Unexpected mocked get called with "
-        "[url={}][headers={}][params={}]".format(url, headers, params)
+        "[method={}][url={}][headers={}][params={}]".format(method, url, headers, params)
     )
 
-
-class MockSession(requests.Session):
-    # Without this the call to update headers fails since
-    # headers attribute is not instantiated by default
-    headers = {}
-
+@patch("requests.post", side_effect=mocked_post, autospec=True)
+@patch.object(requests.Session, 'request', autospec=True, side_effect=mocked_request)
+@patch.object(requests.Session, 'post', autospec=True, side_effect=mocked_post_with_self)
+@patch('time.sleep', return_value=None)
 class TestClientRetries(unittest.TestCase):
     """
     Ensure certain status code responses trigger retries
@@ -147,96 +92,70 @@ class TestClientRetries(unittest.TestCase):
         }
         self.config_path = '/tmp/fake-config-path'
 
-    @patch("requests.post", side_effect=mocked_post, autospec=True)
-    @patch.object(requests.Session, 'request', autospec=True, side_effect=mocked_request)
-    @patch.object(requests.Session, 'post', autospec=True, side_effect=mocked_post_with_self)
-    @patch('time.sleep', return_value=None)
+    def test_non_json_response_triggers_retry_backoff(self, mocked_time_sleep, mocked_session_post, mocked_session_request, mocked_request_post):
+        client = Client(self.config, self.config_path)
+        with self.assertRaisesRegex(requests.exceptions.RequestException, 'Raise for status'):
+            client.post("NoJsonData")
+
+        # Assert we retried 3 times until failing the last one
+        # max tries = 4
+        self.assertEqual(mocked_session_post.call_count, 4)
+
     def test_429_triggers_retry_backoff(self, mocked_time_sleep, mocked_session_post, mocked_session_request, mocked_request_post):
         client = Client(self.config, self.config_path)
-        with self.assertRaisesRegex(requests.exceptions.RequestException, 'Raise for status') as context_manager:
+        with self.assertRaisesRegex(requests.exceptions.RequestException, 'Raise for status'):
             client.post("429-RESOURCE_EXHAUSTED")
 
-        self.assertIsNotNone(context_manager)
         # Assert we retried 3 times until failing the last one
         # max tries = 4
         self.assertEqual(mocked_session_post.call_count, 4)
 
-    @patch("requests.post", side_effect=mocked_post, autospec=True)
-    @patch.object(requests.Session, 'request', autospec=True, side_effect=mocked_request)
-    @patch.object(requests.Session, 'post', autospec=True, side_effect=mocked_post_with_self)
-    @patch('time.sleep', return_value=None)
     def test_503_unavailable_triggers_retry_backoff(self, mocked_time_sleep, mocked_session_post, mocked_session_request, mocked_request_post):
         client = Client(self.config, self.config_path)
-        with self.assertRaisesRegex(requests.exceptions.RequestException, 'Raise for status') as context_manager:
+        with self.assertRaisesRegex(requests.exceptions.RequestException, 'Raise for status'):
             client.post("503-UNAVAILABLE")
 
-        self.assertIsNotNone(context_manager)
         # Assert we retried 3 times until failing the last one
         # max tries = 4
         self.assertEqual(mocked_session_post.call_count, 4)
 
-    @patch("requests.post", side_effect=mocked_post, autospec=True)
-    @patch.object(requests.Session, 'request', autospec=True, side_effect=mocked_request)
-    @patch.object(requests.Session, 'post', autospec=True, side_effect=mocked_post_with_self)
-    @patch('time.sleep', return_value=None)
     def test_503_backend_triggers_no_retry(self, mocked_time_sleep, mocked_session_post, mocked_session_request, mocked_request_post):
         client = Client(self.config, self.config_path)
-        with self.assertRaisesRegex(requests.exceptions.RequestException, 'Raise for status') as context_manager:
+        with self.assertRaisesRegex(requests.exceptions.RequestException, 'Raise for status'):
             client.post("503-BACKENDERROR")
 
-        self.assertIsNotNone(context_manager)
         # Assert we gave up only after the first try
         self.assertEqual(mocked_session_post.call_count, 1)
 
-    @patch("requests.post", side_effect=mocked_post, autospec=True)
-    @patch.object(requests.Session, 'request', autospec=True, side_effect=mocked_request)
-    @patch.object(requests.Session, 'post', autospec=True, side_effect=mocked_post_with_self)
-    @patch('time.sleep', return_value=None)
     def test_500_backend_triggers_no_retry(self, mocked_time_sleep, mocked_session_post, mocked_session_request, mocked_request_post):
         client = Client(self.config, self.config_path)
-        with self.assertRaisesRegex(requests.exceptions.RequestException, 'Raise for status') as context_manager:
+        with self.assertRaisesRegex(requests.exceptions.RequestException, 'Raise for status'):
             client.post("500-INTERNAL")
 
-        self.assertIsNotNone(context_manager)
         # Assert we gave up only after the first try
         self.assertEqual(mocked_session_post.call_count, 1)
 
 
-    @patch("requests.post", side_effect=mocked_post, autospec=True)
-    @patch.object(requests.Session, 'request', autospec=True, side_effect=mocked_request)
-    @patch.object(requests.Session, 'post', autospec=True, side_effect=mocked_post_with_self)
-    @patch('time.sleep', return_value=None)
     def test_400_backend_triggers_no_retry(self, mocked_time_sleep, mocked_session_post, mocked_session_request, mocked_request_post):
         client = Client(self.config, self.config_path)
-        with self.assertRaisesRegex(Exception, 'Client Error, error message') as context_manager:
+        with self.assertRaisesRegex(Exception, 'Client Error, error message'):
             client.post("400-INVALID_ARGUMENT")
 
-        self.assertIsNotNone(context_manager)
         # Assert we gave up only after the first try
         self.assertEqual(mocked_session_post.call_count, 1)
 
-    @patch("requests.post", side_effect=mocked_post, autospec=True)
-    @patch.object(requests.Session, 'request', autospec=True, side_effect=mocked_request)
-    @patch.object(requests.Session, 'post', autospec=True, side_effect=mocked_post_with_self)
-    @patch('time.sleep', return_value=None)
     def test_401_backend_triggers_no_retry(self, mocked_time_sleep, mocked_session_post, mocked_session_request, mocked_request_post):
         client = Client(self.config, self.config_path)
-        with self.assertRaisesRegex(Exception, 'Client Error, error message') as context_manager:
+        with self.assertRaisesRegex(Exception, 'Client Error, error message'):
             client.post("401-UNAUTHENTICATED")
 
-        self.assertIsNotNone(context_manager)
         # Assert we gave up only after the first try
         self.assertEqual(mocked_session_post.call_count, 1)
 
-    @patch("requests.post", side_effect=mocked_post, autospec=True)
-    @patch.object(requests.Session, 'request', autospec=True, side_effect=mocked_request)
-    @patch.object(requests.Session, 'post', autospec=True, side_effect=mocked_post_with_self)
-    @patch('time.sleep', return_value=None)
     def test_403_backend_triggers_no_retry(self, mocked_time_sleep, mocked_session_post, mocked_session_request, mocked_request_post):
         client = Client(self.config, self.config_path)
-        with self.assertRaisesRegex(Exception, 'Client Error, error message') as context_manager:
+        with self.assertRaisesRegex(Exception, 'Client Error, error message'):
             client.post("403-PERMISSION_DENIED")
 
-        self.assertIsNotNone(context_manager)
         # Assert we gave up only after the first try
         self.assertEqual(mocked_session_post.call_count, 1)

--- a/tests/unittests/test_client_utilities.py
+++ b/tests/unittests/test_client_utilities.py
@@ -6,17 +6,16 @@ from tap_google_analytics.client import Client
 
 
 class MockResponse:
-    def __init__(self, json_data, status_code, do_raise_for_status=False):
+    def __init__(self, json_data, status_code):
         self.json_data = json_data
         self.status_code = status_code
-        self.do_raise_for_status = do_raise_for_status
 
     def json(self):
         return self.json_data
 
     def raise_for_status(self):
-        if self.do_raise_for_status:
-            raise requests.exceptions.RequestException("Raise for status")
+        if self.status_code >= 400:
+            raise requests.exceptions.RequestException("Raise for status", response=self)
         else:
             return None
 
@@ -24,24 +23,76 @@ def mocked_post_with_self(self, url, headers=None, params=None, json=None):
     return mocked_post(url, headers=headers, params=params, json=json)
 
 def mocked_post(url, headers=None, params=None, json=None, data=None):
-    if url == "429-error-do-raise-for-status":
+    if url == "429-RESOURCE_EXHAUSTED":
         return MockResponse(
             {
                 "error": {
-                    "message": "retry error message"
+                    "code": 429,
+                    "message": "error message",
+                    "status": "RESOURCE_EXHAUSTED"
                 }
             },
-            429,
-            do_raise_for_status=True)
-    elif url == "503-error-do-raise-for-status":
+            429)
+    elif url == "400-INVALID_ARGUMENT":
         return MockResponse(
             {
                 "error": {
-                    "message": "retry error message"
+                    "code": 400,
+                    "message": "error message",
+                    "status": "INVALID_ARGUMENT"
                 }
             },
-            503,
-            do_raise_for_status=True)
+            400)
+    elif url == "401-UNAUTHENTICATED":
+        return MockResponse(
+            {
+                "error": {
+                    "code": 401,
+                    "message": "error message",
+                    "status": "UNAUTHENTICATED"
+                }
+            },
+            401)
+    elif url == "403-PERMISSION_DENIED":
+        return MockResponse(
+            {
+                "error": {
+                    "code": 403,
+                    "message": "error message",
+                    "status": "PERMISSION_DENIED"
+                }
+            },
+            403)
+    elif url == "503-UNAVAILABLE":
+        return MockResponse(
+            {
+                "error": {
+                    "code": 503,
+                    "message": "error message",
+                    "status": "UNAVAILABLE"
+                }
+            },
+            503)
+    elif url == "503-BACKENDERROR":
+        return MockResponse(
+            {
+                "error": {
+                    "code": 503,
+                    "message": "error message",
+                    "status": "BACKEND_ERROR"
+                }
+            },
+            503)
+    elif url == "500-INTERNAL":
+        return MockResponse(
+            {
+                "error": {
+                    "code": 500,
+                    "message": "error message",
+                    "status": "INTERNAL"
+                }
+            },
+            500)
     elif url == "https://oauth2.googleapis.com/token":
         return MockResponse(
             {
@@ -81,6 +132,7 @@ class MockSession(requests.Session):
 class TestClientRetries(unittest.TestCase):
     """
     Ensure certain status code responses trigger retries
+    See documentation at https://developers.google.com/analytics/devguides/reporting/core/v4/errors
     """
 
     def setUp(self):
@@ -102,7 +154,7 @@ class TestClientRetries(unittest.TestCase):
     def test_429_triggers_retry_backoff(self, mocked_time_sleep, mocked_session_post, mocked_session_request, mocked_request_post):
         client = Client(self.config, self.config_path)
         with self.assertRaisesRegex(requests.exceptions.RequestException, 'Raise for status') as context_manager:
-            client.post("429-error-do-raise-for-status")
+            client.post("429-RESOURCE_EXHAUSTED")
 
         self.assertIsNotNone(context_manager)
         # Assert we retried 3 times until failing the last one
@@ -113,12 +165,78 @@ class TestClientRetries(unittest.TestCase):
     @patch.object(requests.Session, 'request', autospec=True, side_effect=mocked_request)
     @patch.object(requests.Session, 'post', autospec=True, side_effect=mocked_post_with_self)
     @patch('time.sleep', return_value=None)
-    def test_503_triggers_retry_backoff(self, mocked_time_sleep, mocked_session_post, mocked_session_request, mocked_request_post):
+    def test_503_unavailable_triggers_retry_backoff(self, mocked_time_sleep, mocked_session_post, mocked_session_request, mocked_request_post):
         client = Client(self.config, self.config_path)
         with self.assertRaisesRegex(requests.exceptions.RequestException, 'Raise for status') as context_manager:
-            client.post("503-error-do-raise-for-status")
+            client.post("503-UNAVAILABLE")
 
         self.assertIsNotNone(context_manager)
         # Assert we retried 3 times until failing the last one
         # max tries = 4
         self.assertEqual(mocked_session_post.call_count, 4)
+
+    @patch("requests.post", side_effect=mocked_post, autospec=True)
+    @patch.object(requests.Session, 'request', autospec=True, side_effect=mocked_request)
+    @patch.object(requests.Session, 'post', autospec=True, side_effect=mocked_post_with_self)
+    @patch('time.sleep', return_value=None)
+    def test_503_backend_triggers_no_retry(self, mocked_time_sleep, mocked_session_post, mocked_session_request, mocked_request_post):
+        client = Client(self.config, self.config_path)
+        with self.assertRaisesRegex(requests.exceptions.RequestException, 'Raise for status') as context_manager:
+            client.post("503-BACKENDERROR")
+
+        self.assertIsNotNone(context_manager)
+        # Assert we gave up only after the first try
+        self.assertEqual(mocked_session_post.call_count, 1)
+
+    @patch("requests.post", side_effect=mocked_post, autospec=True)
+    @patch.object(requests.Session, 'request', autospec=True, side_effect=mocked_request)
+    @patch.object(requests.Session, 'post', autospec=True, side_effect=mocked_post_with_self)
+    @patch('time.sleep', return_value=None)
+    def test_500_backend_triggers_no_retry(self, mocked_time_sleep, mocked_session_post, mocked_session_request, mocked_request_post):
+        client = Client(self.config, self.config_path)
+        with self.assertRaisesRegex(requests.exceptions.RequestException, 'Raise for status') as context_manager:
+            client.post("500-INTERNAL")
+
+        self.assertIsNotNone(context_manager)
+        # Assert we gave up only after the first try
+        self.assertEqual(mocked_session_post.call_count, 1)
+
+
+    @patch("requests.post", side_effect=mocked_post, autospec=True)
+    @patch.object(requests.Session, 'request', autospec=True, side_effect=mocked_request)
+    @patch.object(requests.Session, 'post', autospec=True, side_effect=mocked_post_with_self)
+    @patch('time.sleep', return_value=None)
+    def test_400_backend_triggers_no_retry(self, mocked_time_sleep, mocked_session_post, mocked_session_request, mocked_request_post):
+        client = Client(self.config, self.config_path)
+        with self.assertRaisesRegex(requests.exceptions.RequestException, 'Raise for status') as context_manager:
+            client.post("400-INVALID_ARGUMENT")
+
+        self.assertIsNotNone(context_manager)
+        # Assert we gave up only after the first try
+        self.assertEqual(mocked_session_post.call_count, 1)
+
+    @patch("requests.post", side_effect=mocked_post, autospec=True)
+    @patch.object(requests.Session, 'request', autospec=True, side_effect=mocked_request)
+    @patch.object(requests.Session, 'post', autospec=True, side_effect=mocked_post_with_self)
+    @patch('time.sleep', return_value=None)
+    def test_401_backend_triggers_no_retry(self, mocked_time_sleep, mocked_session_post, mocked_session_request, mocked_request_post):
+        client = Client(self.config, self.config_path)
+        with self.assertRaisesRegex(requests.exceptions.RequestException, 'Raise for status') as context_manager:
+            client.post("401-UNAUTHENTICATED")
+
+        self.assertIsNotNone(context_manager)
+        # Assert we gave up only after the first try
+        self.assertEqual(mocked_session_post.call_count, 1)
+
+    @patch("requests.post", side_effect=mocked_post, autospec=True)
+    @patch.object(requests.Session, 'request', autospec=True, side_effect=mocked_request)
+    @patch.object(requests.Session, 'post', autospec=True, side_effect=mocked_post_with_self)
+    @patch('time.sleep', return_value=None)
+    def test_403_backend_triggers_no_retry(self, mocked_time_sleep, mocked_session_post, mocked_session_request, mocked_request_post):
+        client = Client(self.config, self.config_path)
+        with self.assertRaisesRegex(requests.exceptions.RequestException, 'Raise for status') as context_manager:
+            client.post("403-PERMISSION_DENIED")
+
+        self.assertIsNotNone(context_manager)
+        # Assert we gave up only after the first try
+        self.assertEqual(mocked_session_post.call_count, 1)

--- a/tests/unittests/test_client_utilities.py
+++ b/tests/unittests/test_client_utilities.py
@@ -208,7 +208,7 @@ class TestClientRetries(unittest.TestCase):
     @patch('time.sleep', return_value=None)
     def test_400_backend_triggers_no_retry(self, mocked_time_sleep, mocked_session_post, mocked_session_request, mocked_request_post):
         client = Client(self.config, self.config_path)
-        with self.assertRaisesRegex(requests.exceptions.RequestException, 'Raise for status') as context_manager:
+        with self.assertRaisesRegex(Exception, 'Client Error, error message') as context_manager:
             client.post("400-INVALID_ARGUMENT")
 
         self.assertIsNotNone(context_manager)
@@ -221,7 +221,7 @@ class TestClientRetries(unittest.TestCase):
     @patch('time.sleep', return_value=None)
     def test_401_backend_triggers_no_retry(self, mocked_time_sleep, mocked_session_post, mocked_session_request, mocked_request_post):
         client = Client(self.config, self.config_path)
-        with self.assertRaisesRegex(requests.exceptions.RequestException, 'Raise for status') as context_manager:
+        with self.assertRaisesRegex(Exception, 'Client Error, error message') as context_manager:
             client.post("401-UNAUTHENTICATED")
 
         self.assertIsNotNone(context_manager)
@@ -234,7 +234,7 @@ class TestClientRetries(unittest.TestCase):
     @patch('time.sleep', return_value=None)
     def test_403_backend_triggers_no_retry(self, mocked_time_sleep, mocked_session_post, mocked_session_request, mocked_request_post):
         client = Client(self.config, self.config_path)
-        with self.assertRaisesRegex(requests.exceptions.RequestException, 'Raise for status') as context_manager:
+        with self.assertRaisesRegex(Exception, 'Client Error, error message') as context_manager:
             client.post("403-PERMISSION_DENIED")
 
         self.assertIsNotNone(context_manager)

--- a/tests/unittests/test_client_utilities.py
+++ b/tests/unittests/test_client_utilities.py
@@ -1,0 +1,124 @@
+import unittest
+import requests
+from unittest.mock import Mock, MagicMock, patch
+
+from tap_google_analytics.client import Client
+
+
+class MockResponse:
+    def __init__(self, json_data, status_code, do_raise_for_status=False):
+        self.json_data = json_data
+        self.status_code = status_code
+        self.do_raise_for_status = do_raise_for_status
+
+    def json(self):
+        return self.json_data
+
+    def raise_for_status(self):
+        if self.do_raise_for_status:
+            raise requests.exceptions.RequestException("Raise for status")
+        else:
+            return None
+
+def mocked_post_with_self(self, url, headers=None, params=None, json=None):
+    return mocked_post(url, headers=headers, params=params, json=json)
+
+def mocked_post(url, headers=None, params=None, json=None, data=None):
+    if url == "429-error-do-raise-for-status":
+        return MockResponse(
+            {
+                "error": {
+                    "message": "retry error message"
+                }
+            },
+            429,
+            do_raise_for_status=True)
+    elif url == "503-error-do-raise-for-status":
+        return MockResponse(
+            {
+                "error": {
+                    "message": "retry error message"
+                }
+            },
+            503,
+            do_raise_for_status=True)
+    elif url == "https://oauth2.googleapis.com/token":
+        return MockResponse(
+            {
+                "access_token": "access_token",
+                "expires_in": 9999999999,
+            },
+            200)
+
+    raise NotImplementedError(
+        "Unexpected mocked post called with "
+        "[url={}][headers={}][params={}][json={}][data={}]".format(url, headers, params, json, data)
+    )
+
+def mocked_request(self, method, url, headers=None, params=None):
+    if method != 'GET':
+        raise NotImplementedError(
+            "Unexpected mocked get called with "
+            "[url={}][headers={}][params={}]".format(url, headers, params)
+        )
+
+    if url == "https://www.googleapis.com/analytics/v3/management/accountSummaries":
+        return MockResponse({
+            'items': []
+        }, 200)
+
+    raise NotImplementedError(
+        "Unexpected mocked get called with "
+        "[url={}][headers={}][params={}]".format(url, headers, params)
+    )
+
+
+class MockSession(requests.Session):
+    # Without this the call to update headers fails since
+    # headers attribute is not instantiated by default
+    headers = {}
+
+class TestClientRetries(unittest.TestCase):
+    """
+    Ensure certain status code responses trigger retries
+    """
+
+    def setUp(self):
+        self.config = {
+            'auth_method': 'oauth2',
+            'refresh_token': 'refresh_token',
+            'client_id': 'client_id',
+            'client_secret': 'client_secret',
+            'quota_user': 'quota_user',
+            'user_agent': 'user_agent',
+            'view_id': 'view_id',
+        }
+        self.config_path = '/tmp/fake-config-path'
+
+    @patch("requests.post", side_effect=mocked_post, autospec=True)
+    @patch.object(requests.Session, 'request', autospec=True, side_effect=mocked_request)
+    @patch.object(requests.Session, 'post', autospec=True, side_effect=mocked_post_with_self)
+    @patch('time.sleep', return_value=None)
+    def test_429_triggers_retry_backoff(self, mocked_time_sleep, mocked_session_post, mocked_session_request, mocked_request_post):
+        client = Client(self.config, self.config_path)
+        with self.assertRaisesRegex(requests.exceptions.RequestException, 'Raise for status') as context_manager:
+            client.post("429-error-do-raise-for-status")
+
+        self.assertIsNotNone(context_manager)
+        # Assert we retried 3 times until failing the last one
+        # max tries = 4
+        self.assertEqual(mocked_session_post.call_count, 4)
+
+    @patch("requests.post", side_effect=mocked_post, autospec=True)
+    @patch.object(requests.Session, 'request', autospec=True, side_effect=mocked_request)
+    @patch.object(requests.Session, 'post', autospec=True, side_effect=mocked_post_with_self)
+    @patch('time.sleep', return_value=None)
+    def test_503_triggers_retry_backoff(self, mocked_time_sleep, mocked_session_post, mocked_session_request, mocked_request_post):
+        client = Client(self.config, self.config_path)
+        with self.assertRaisesRegex(requests.exceptions.RequestException, 'Raise for status') as context_manager:
+            client.post("503-error-do-raise-for-status")
+
+        self.assertIsNotNone(context_manager)
+        # Assert we retried 3 times until failing the last one
+        # max tries = 4
+        self.assertEqual(mocked_session_post.call_count, 4)


### PR DESCRIPTION
# Description of change
Add unit testing for retries on 429s and 503s

# QA steps
 - [x] automated tests passing
 - [ ] manual qa steps passing (list below)
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
