### PR TITLE
added session for request in _ensure_access_token

### DIFF
--- a/tap_google_analytics/client.py
+++ b/tap_google_analytics/client.py
@@ -217,7 +217,7 @@ class Client():
                 "assertion": JWT().encode(message, signing_key, 'RS256')
             }
 
-        token_response = requests.post("https://oauth2.googleapis.com/token", data=payload)
+        token_response = self.session.post("https://oauth2.googleapis.com/token", json=payload)
 
         token_response.raise_for_status()
 

--- a/tests/unittests/test_client_utilities.py
+++ b/tests/unittests/test_client_utilities.py
@@ -193,5 +193,5 @@ class TestClientTCPKeepalive(unittest.TestCase):
 
     def test_keepalive_on_session_request(self):
         client = Client(self.config, self.config_path)
-        LOGGER.info("KWARGS: {}".format(self.request_spy.call_args.kwargs))
+        LOGGER.info("KWARGS: {}".format(self.request_spy.call_args))
         self.assertEqual(self.request_spy.call_args.kwargs.get('headers', {}).get('Connection'), 'keep-alive')

--- a/tests/unittests/test_client_utilities.py
+++ b/tests/unittests/test_client_utilities.py
@@ -193,5 +193,4 @@ class TestClientTCPKeepalive(unittest.TestCase):
 
     def test_keepalive_on_session_request(self):
         client = Client(self.config, self.config_path)
-        LOGGER.info("KWARGS: {}".format(self.request_spy.call_args))
-        self.assertEqual(self.request_spy.call_args.kwargs.get('headers', {}).get('Connection'), 'keep-alive')
+        self.assertEqual(self.request_spy.call_args[1].get('headers', {}).get('Connection'), 'keep-alive')

--- a/tests/unittests/test_client_utilities.py
+++ b/tests/unittests/test_client_utilities.py
@@ -6,6 +6,10 @@ from unittest.mock import MagicMock
 
 from tap_google_analytics.client import Client
 
+import singer
+
+LOGGER = singer.get_logger()
+
 
 class MockResponse:
     def __init__(self, json_data, status_code):
@@ -189,5 +193,5 @@ class TestClientTCPKeepalive(unittest.TestCase):
 
     def test_keepalive_on_session_request(self):
         client = Client(self.config, self.config_path)
-
+        LOGGER.info("KWARGS: {}".format(self.request_spy.call_args.kwargs))
         self.assertEqual(self.request_spy.call_args.kwargs.get('headers', {}).get('Connection'), 'keep-alive')

--- a/tests/unittests/test_client_utilities.py
+++ b/tests/unittests/test_client_utilities.py
@@ -2,6 +2,7 @@ import unittest
 import requests
 import re
 from unittest.mock import patch
+from unittest.mock import MagicMock
 
 from tap_google_analytics.client import Client
 
@@ -99,7 +100,7 @@ class TestClientRetries(unittest.TestCase):
 
         # Assert we retried 3 times until failing the last one
         # max tries = 4
-        self.assertEqual(mocked_session_post.call_count, 4)
+        self.assertEqual(mocked_session_post.call_count, 5)
 
     def test_429_triggers_retry_backoff(self, mocked_time_sleep, mocked_session_post, mocked_session_request, mocked_request_post):
         client = Client(self.config, self.config_path)
@@ -108,7 +109,7 @@ class TestClientRetries(unittest.TestCase):
 
         # Assert we retried 3 times until failing the last one
         # max tries = 4
-        self.assertEqual(mocked_session_post.call_count, 4)
+        self.assertEqual(mocked_session_post.call_count, 5)
 
     def test_503_unavailable_triggers_retry_backoff(self, mocked_time_sleep, mocked_session_post, mocked_session_request, mocked_request_post):
         client = Client(self.config, self.config_path)
@@ -117,7 +118,7 @@ class TestClientRetries(unittest.TestCase):
 
         # Assert we retried 3 times until failing the last one
         # max tries = 4
-        self.assertEqual(mocked_session_post.call_count, 4)
+        self.assertEqual(mocked_session_post.call_count, 5)
 
     def test_503_backend_triggers_no_retry(self, mocked_time_sleep, mocked_session_post, mocked_session_request, mocked_request_post):
         client = Client(self.config, self.config_path)
@@ -125,7 +126,7 @@ class TestClientRetries(unittest.TestCase):
             client.post("503-BACKENDERROR")
 
         # Assert we gave up only after the first try
-        self.assertEqual(mocked_session_post.call_count, 1)
+        self.assertEqual(mocked_session_post.call_count, 2)
 
     def test_500_backend_triggers_no_retry(self, mocked_time_sleep, mocked_session_post, mocked_session_request, mocked_request_post):
         client = Client(self.config, self.config_path)
@@ -133,7 +134,7 @@ class TestClientRetries(unittest.TestCase):
             client.post("500-INTERNAL")
 
         # Assert we gave up only after the first try
-        self.assertEqual(mocked_session_post.call_count, 1)
+        self.assertEqual(mocked_session_post.call_count, 2)
 
 
     def test_400_backend_triggers_no_retry(self, mocked_time_sleep, mocked_session_post, mocked_session_request, mocked_request_post):
@@ -142,7 +143,7 @@ class TestClientRetries(unittest.TestCase):
             client.post("400-INVALID_ARGUMENT")
 
         # Assert we gave up only after the first try
-        self.assertEqual(mocked_session_post.call_count, 1)
+        self.assertEqual(mocked_session_post.call_count, 2)
 
     def test_401_backend_triggers_no_retry(self, mocked_time_sleep, mocked_session_post, mocked_session_request, mocked_request_post):
         client = Client(self.config, self.config_path)
@@ -150,7 +151,7 @@ class TestClientRetries(unittest.TestCase):
             client.post("401-UNAUTHENTICATED")
 
         # Assert we gave up only after the first try
-        self.assertEqual(mocked_session_post.call_count, 1)
+        self.assertEqual(mocked_session_post.call_count, 2)
 
     def test_403_backend_triggers_no_retry(self, mocked_time_sleep, mocked_session_post, mocked_session_request, mocked_request_post):
         client = Client(self.config, self.config_path)
@@ -158,4 +159,35 @@ class TestClientRetries(unittest.TestCase):
             client.post("403-PERMISSION_DENIED")
 
         # Assert we gave up only after the first try
-        self.assertEqual(mocked_session_post.call_count, 1)
+        self.assertEqual(mocked_session_post.call_count, 2)
+
+
+
+class TestClientTCPKeepalive(unittest.TestCase):
+    def setUp(self):
+        self.request_spy = MagicMock()
+        requests.models.PreparedRequest.prepare = self.request_spy
+
+        mock_adaptor = MagicMock()
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_adaptor.send = MagicMock(return_value=mock_response)
+        requests.sessions.Session.get_adapter = MagicMock(return_value=mock_adaptor)
+
+        requests.sessions.Session.resolve_redirects = MagicMock()
+
+        self.config = {
+            'auth_method': 'oauth2',
+            'refresh_token': 'refresh_token',
+            'client_id': 'client_id',
+            'client_secret': 'client_secret',
+            'quota_user': 'quota_user',
+            'user_agent': 'user_agent',
+            'view_id': 'view_id',
+        }
+        self.config_path = '/tmp/fake-config-path'
+
+    def test_keepalive_on_session_request(self):
+        client = Client(self.config, self.config_path)
+
+        self.assertEqual(self.request_spy.call_args.kwargs.get('headers', {}).get('Connection'), 'keep-alive')


### PR DESCRIPTION
# Description of change
this is a fix in response to this ticket
https://stitchdata.atlassian.net/browse/SUP-2176
we wrote unit test to make sure a `keep-alive` header is on the request, which would ensure that the connection does not snap.
# QA steps
 - [ ] automated tests passing
 - [ ] manual qa steps passing (list below)
    - the unit tests pass
    - we ran the tap in discovery and that gets past the `_ensure_access_token` function and successfully writes a catalog
# Risks
 - low
 
# Rollback steps
 - revert this branch
