### PR TITLE
Pin jwt to 1.2.0 to avoid timing vulnerabilities in cryptography@2.9.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
         "singer-python==5.9.0",
         "requests==2.22.0",
         "backoff==1.8.0",
-        "jwt==0.6.1"
+        "jwt==1.2.0"
     ],
     extras_require={
         'dev': [


### PR DESCRIPTION
# Description of change

Our security team flagged this as a vulnerability. `jwt@0.6.1` depends on `cryptography@2.9.2`, which contains timing vulnerabilities. Upgrading to at least 1.1.0 will fix this. [`python-jwt`](https://github.com/GehirnInc/python-jwt)  does not have a CHANGELOG, but scanning the commits between 0.6.1 & 1.2.0 as well as the documentation shows that the API as used by `tap-google-analytics` has not changed.

# QA steps
 - [ ] automated tests passing
 - [ ] manual qa steps passing (list below)
 
# Risks
 - jwt@1.1.0 (the earliest version that depends on a patched version of cryptography) also dropped support for Python < 3.6 (all of which are EoL).
 
# Rollback steps
 - revert this branch
