### PR TITLE
1.0.5: Decode the json cubes file from bytes as utf8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.0.5
+  * When loading a file via `pkgutil` it must be decoded from bytes [#57](https://github.com/singer-io/tap-google-analytics/pull/56)
+
 ## 1.0.4
   * Fix inclusion of `ga_cubes.json` and remove dynamic pulling of the file for reliability [#56](https://github.com/singer-io/tap-google-analytics/pull/56)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-google-analytics",
-    version="1.0.4",
+    version="1.0.5",
     description="Singer.io tap for extracting data",
     author="Stitch",
     url="http://singer.io",

--- a/tap_google_analytics/client.py
+++ b/tap_google_analytics/client.py
@@ -272,7 +272,7 @@ class Client():
         return metadata_response.json()
 
     def get_raw_cubes(self): # pylint: disable=no-self-use
-        return json.loads(pkgutil.get_data(__package__, "ga_cubes.json"))
+        return json.loads(pkgutil.get_data(__package__, "ga_cubes.json").decode('utf-8'))
 
     def get_account_summaries_for_token(self):
         """


### PR DESCRIPTION
# Description of change
Reading the file returns the data as a bytes string, rather than a string. This must be decoded as `utf-8`.

The current theory is that testing and local development is using Python 3.8.6, which must have extended the `json` module to be able to handle byte strings as utf-8.

# QA steps
 - [ ] automated tests passing
 - [X] manual qa steps passing (list below)
   - [X] Ran through the load with decode in python at a breakpoint

# Risks
 - Low, it's broken still currently
 
# Rollback steps
 - revert this branch and #56
