### PR TITLE
don't pin ipdb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
             python3 -mvenv /usr/local/share/virtualenvs/tap-google-analytics
             source /usr/local/share/virtualenvs/tap-google-analytics/bin/activate
             pip install -U pip setuptools
-            pip install .[dev]
+            pip install .[test]
       - run:
           name: 'pylint'
           command: |

--- a/setup.py
+++ b/setup.py
@@ -16,10 +16,12 @@ setup(
         "jwt==0.6.1"
     ],
     extras_require={
-        'dev': [
-            'ipdb==0.11',
+        'test': [
             'pylint',
             'nose'
+        ],
+        'dev': [
+            'ipdb',
         ]
     },
     entry_points="""


### PR DESCRIPTION
# Description of change
Fix the setup.
Put ipdb into a dev group alone, put nose and pylint into a test group. Don't pin the ipdb version.
# QA steps
 - [ ] automated tests passing
 - [ ] manual qa steps passing (list below)
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
