### PR TITLE
Add a string fallback in case we receive non integer values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.1.0
+  * Add a string fallback schema to integer override fields [#61](https://github.com/singer-io/tap-google-analytics/pull/61)
+
 ## 1.0.5
   * When loading a file via `pkgutil` it must be decoded from bytes [#57](https://github.com/singer-io/tap-google-analytics/pull/56)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-google-analytics",
-    version="1.0.5",
+    version="1.1.0",
     description="Singer.io tap for extracting data",
     author="Stitch",
     url="http://singer.io",

--- a/tap_google_analytics/discover.py
+++ b/tap_google_analytics/discover.py
@@ -55,7 +55,7 @@ def type_to_schema(ga_type, field_id):
     elif ga_type == 'TIME':
         return {"type": ["string", "null"]}
     elif ga_type == 'INTEGER' or field_id in integer_field_overrides:
-        return {"type": ["integer", "null"]}
+        return {"type": ["integer", "string", "null"]}
     elif ga_type == 'FLOAT' or field_id in float_field_overrides:
         return {"type": ["number", "null"]}
     elif ga_type == 'STRING':

--- a/tap_google_analytics/discover.py
+++ b/tap_google_analytics/discover.py
@@ -54,8 +54,10 @@ def type_to_schema(ga_type, field_id):
         return {"type": ["number", "null"]}
     elif ga_type == 'TIME':
         return {"type": ["string", "null"]}
-    elif ga_type == 'INTEGER' or field_id in integer_field_overrides:
+    elif field_id in integer_field_overrides:
         return {"type": ["integer", "string", "null"]}
+    elif ga_type == 'INTEGER':
+        return {"type": ["integer", "null"]}
     elif ga_type == 'FLOAT' or field_id in float_field_overrides:
         return {"type": ["number", "null"]}
     elif ga_type == 'STRING':

--- a/tests/unittests/test_discovery_utilities.py
+++ b/tests/unittests/test_discovery_utilities.py
@@ -204,15 +204,6 @@ class TestTypesToSchema(unittest.TestCase):
 
         self.assertEqual(expected, actual)
 
-
-        actual = types_to_schema(['CURRENCY', 'TIME', 'INTEGER'], 'ga:testField')
-
-        expected = {'anyOf': [{'type': ['integer', 'null']},
-                              {'type': ['number', 'null']},
-                              {'type': ['string', 'null']}]}
-
-        self.assertEqual(expected, actual)
-
     def test_multiple_types_with_duplicates_returns_no_duplicates(self):
         actual = types_to_schema(['CURRENCY', 'PERCENT', 'INTEGER'], 'ga:testField')
 

--- a/tests/unittests/test_discovery_utilities.py
+++ b/tests/unittests/test_discovery_utilities.py
@@ -198,7 +198,7 @@ class TestTypesToSchema(unittest.TestCase):
         # CURRENCY = number, TIME = string, INTEGER = integer
         actual = types_to_schema(['CURRENCY', 'TIME', 'INTEGER'], 'ga:testField')
 
-        expected = {'anyOf': [{'type': ['integer', 'null']},
+        expected = {'anyOf': [{'type': ['integer', 'string', 'null']},
                               {'type': ['number', 'null']},
                               {'type': ['string', 'null']}]}
 
@@ -207,7 +207,7 @@ class TestTypesToSchema(unittest.TestCase):
     def test_multiple_types_with_duplicates_returns_no_duplicates(self):
         actual = types_to_schema(['CURRENCY', 'PERCENT', 'INTEGER'], 'ga:testField')
 
-        expected = {'anyOf': [{'type': ['integer', 'null']},
+        expected = {'anyOf': [{'type': ['integer', 'string', 'null']},
                               {'type': ['number', 'null']}]}
 
         self.assertEqual(expected, actual)

--- a/tests/unittests/test_discovery_utilities.py
+++ b/tests/unittests/test_discovery_utilities.py
@@ -198,7 +198,16 @@ class TestTypesToSchema(unittest.TestCase):
         # CURRENCY = number, TIME = string, INTEGER = integer
         actual = types_to_schema(['CURRENCY', 'TIME', 'INTEGER'], 'ga:testField')
 
-        expected = {'anyOf': [{'type': ['integer', 'string', 'null']},
+        expected = {'anyOf': [{'type': ['integer', 'null']},
+                              {'type': ['number', 'null']},
+                              {'type': ['string', 'null']}]}
+
+        self.assertEqual(expected, actual)
+
+
+        actual = types_to_schema(['CURRENCY', 'TIME', 'INTEGER'], 'ga:testField')
+
+        expected = {'anyOf': [{'type': ['integer', 'null']},
                               {'type': ['number', 'null']},
                               {'type': ['string', 'null']}]}
 
@@ -207,7 +216,14 @@ class TestTypesToSchema(unittest.TestCase):
     def test_multiple_types_with_duplicates_returns_no_duplicates(self):
         actual = types_to_schema(['CURRENCY', 'PERCENT', 'INTEGER'], 'ga:testField')
 
-        expected = {'anyOf': [{'type': ['integer', 'string', 'null']},
+        expected = {'anyOf': [{'type': ['integer', 'null']},
                               {'type': ['number', 'null']}]}
+
+        self.assertEqual(expected, actual)
+
+    def test_integer_override_schema_includes_string_fallback(self):
+        actual = types_to_schema(['INTEGER'], 'ga:subContinentCode')
+
+        expected = {'type': ['integer', 'string', 'null']}
 
         self.assertEqual(expected, actual)


### PR DESCRIPTION
# Description of change
Add a string type fallback in case the integer override fields do not receive an integer.

# QA steps
 - [ ] automated tests passing
 - [ ] manual qa steps passing (list below)
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
