### PR TITLE
TDL-16943 Investigate report replication date failures in regression build

### DIFF
--- a/tests/test_google_analytics_bookmarks.py
+++ b/tests/test_google_analytics_bookmarks.py
@@ -69,11 +69,6 @@ class GoogleAnalyticsBookmarksTest(GoogleAnalyticsBaseTest):
         expected_replication_keys = self.expected_replication_keys()
         expected_replication_methods = self.expected_replication_method()
 
-
-        # BUG_TDL-16943 https://jira.talendforge.org/browse/TDL-16943
-        #    [tap-google-analytics] Investigate report replication date failures in regression build
-        #    To Reproduce: comment/uncomment the marked lines
-
         today = datetime.datetime.utcnow().strftime(self.REPLICATION_KEY_FORMAT)
         self.account_id = self.get_properties()['view_id']
         custom_streams_name_to_id = self.custom_reports_names_to_ids()
@@ -195,22 +190,19 @@ class GoogleAnalyticsBookmarksTest(GoogleAnalyticsBaseTest):
                     second_replication_values_sorted = sorted(second_replication_values)
                     self.assertEqual(second_replication_values_sorted, second_replication_values)
 
-                    # Verify the second sync records respect the previous (simulated) bookmark value
+                   
                     for record in second_sync_messages:
                         with self.subTest(record=record):
+                            # Verify the second sync records respect the previous (simulated) bookmark value
                             self.assertGreaterEqual(record[replication_key], simulated_bookmark_value)
 
-                    # UNCOMMENT START BUG_TDL-16943
-                    # with self.subTest():
-                    #     # Verify today's date is the max replication-key value for the second sync
-                    #     self.assertEqual(second_sync_messages[-1][replication_key], today,
-                    #                      msg=f"today is present in result: {today in second_replication_values}")
+                            # Verify today's date is the max replication-key value for the second sync
+                            self.assertGreaterEqual(today, record[replication_key])
 
-                    # with self.subTest():
-                    #     # Verify today's date is the max replication-key value for the first sync
-                    #     self.assertEqual(first_sync_messages[-1][replication_key], today,
-                    #                      msg=f"today is present in result: {today in first_replication_values}")
-                    # UNCOMMENT END BUG_TDL-16943
+                    for record in first_sync_messages:
+                        with self.subTest(record=record):
+                            # Verify today's date is the max replication-key value for the first sync
+                            self.assertGreaterEqual(today, record[replication_key])
 
                     # NB: We bookmark based on the last date where data "is golden" (unchanging), but will
                     #     replicate data through the date when the sync is ran, in this case today.


### PR DESCRIPTION
# Description of change

- Removed unstable assertion which checked that a sync's bookmarked value was equal to today's date for a report using incremental replication.
- This is invalid because google-analytics bookmarks based on the last record which will not always be for today. 
- Also, based on existing expection  [comments](https://github.com/singer-io/tap-google-analytics/pull/58/files#diff-50f9258374526a5b77b9819ef0f9681c3bcbd8f74218f2b7692bf335ea8e3b73L189), added appropriate assertions.

**Note:** This same issue was mentioned in [#58 ](https://github.com/singer-io/tap-google-analytics/pull/58). But it seems like, the expected [assertion](https://github.com/singer-io/tap-google-analytics/pull/58/files#diff-50f9258374526a5b77b9819ef0f9681c3bcbd8f74218f2b7692bf335ea8e3b73L189) was removed instead of an unexpected assertion.

# QA steps
 - [x] automated tests passing
 - [ ] manual qa steps passing (list below)
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
