### PR TITLE
Tdl 12607 add page size as a configurable property

### DIFF
--- a/tap_google_analytics/__init__.py
+++ b/tap_google_analytics/__init__.py
@@ -11,6 +11,7 @@ from .sync import sync_report
 
 LOGGER = singer.get_logger()
 
+DEFAULT_PAGE_SIZE = 1000
 
 # TODO: Add an integration test with multiple profiles that asserts state
 def clean_state_for_report(config, state, tap_stream_id):
@@ -63,6 +64,9 @@ def do_sync(client, config, catalog, state):
     to sync to generate the required reports.
     """
     selected_streams = catalog.get_selected_streams(state)
+    # If page_size found in config then used it else use default page size.
+    page_size = config.get('page_size', DEFAULT_PAGE_SIZE)
+
     for stream in selected_streams:
         # Transform state for this report to new format before proceeding
         state = clean_state_for_report(config, state, stream.tap_stream_id)
@@ -122,7 +126,7 @@ def do_sync(client, config, catalog, state):
 
             is_historical_sync, start_date = get_start_date(config, report['profile_id'], state, report['id'])
 
-            sync_report(client, schema, report, start_date, end_date, state, is_historical_sync)
+            sync_report(client, schema, report, start_date, end_date, state, page_size, is_historical_sync)
         state.pop('currently_syncing_view', None)
         singer.write_state(state)
     state = singer.set_currently_syncing(state, None)

--- a/tap_google_analytics/client.py
+++ b/tap_google_analytics/client.py
@@ -431,7 +431,7 @@ class Client():
 
     # Sync Requests w/ Pagination and token refresh
     # Docs for more info: https://developers.google.com/analytics/devguides/reporting/core/v4/rest/v4/reports/batchGet
-    def get_report(self, name, profile_id, report_date, metrics, dimensions):
+    def get_report(self, name, profile_id, report_date, metrics, dimensions, page_size):
         """
         Parameters:
         - name - the tap_stream_id of the report being run
@@ -454,6 +454,7 @@ class Client():
                         nextPageToken)
             body = {"reportRequests":
                     [{"viewId": profile_id,
+                      "pageSize": page_size, # Pagination parameter
                       "dateRanges": [{"startDate": report_date_string,
                                       "endDate": report_date_string}],
                       "metrics": [{"expression": m} for m in metrics],

--- a/tap_google_analytics/sync.py
+++ b/tap_google_analytics/sync.py
@@ -95,7 +95,7 @@ def transform_datetimes(rec):
             rec[field_name] = datetime.strptime(value, DATETIME_FORMATS[field_name]).strftime(singer.utils.DATETIME_FMT)
     return rec
 
-def sync_report(client, schema, report, start_date, end_date, state, historically_syncing=False):
+def sync_report(client, schema, report, start_date, end_date, state, page_size, historically_syncing=False):
     """
     Run a sync, beginning from either the start_date or bookmarked date,
     requesting a report per day, until the last full day of data. (e.g.,
@@ -114,7 +114,7 @@ def sync_report(client, schema, report, start_date, end_date, state, historicall
     for report_date in generate_report_dates(start_date, end_date):
         for raw_report_response in client.get_report(report['name'], report['profile_id'],
                                                      report_date, report['metrics'],
-                                                     report['dimensions']):
+                                                     report['dimensions'], page_size):
 
             with singer.metrics.record_counter(report['name']) as counter:
                 time_extracted = singer.utils.now()

--- a/tests/base.py
+++ b/tests/base.py
@@ -50,7 +50,8 @@ class GoogleAnalyticsBaseTest(unittest.TestCase):
         return_value = {
             'start_date' : (dt.utcnow() - timedelta(days=30)).strftime(self.START_DATE_FORMAT),
             'view_id': os.getenv('TAP_GOOGLE_ANALYTICS_VIEW_ID'),
-            'report_definitions': [{"id": "a665732c-d18b-445c-89b2-5ca8928a7305", "name": "Test Report 1"}]
+            'report_definitions': [{"id": "a665732c-d18b-445c-89b2-5ca8928a7305", "name": "Test Report 1"}],
+            'page_size': 1
         }
         if original:
             return return_value
@@ -438,13 +439,20 @@ class GoogleAnalyticsBaseTest(unittest.TestCase):
         return {
             "Test Report 1" : set(),
             "Audience Overview": {
-                "ga:users", "ga:newUsers", "ga:sessions", "ga:sessionsPerUser", "ga:pageviews",
-                "ga:pageviewsPerSession", "ga:sessionDuration", "ga:bounceRate", "ga:date",
-                # "ga:pageviews",
+                'ga:users', 'ga:newUsers', 'ga:sessions', 'ga:bounceRate', 'ga:avgSessionDuration', 'ga:pageviews', 
+                'ga:pageviewsPerSession', 'ga:sessionsPerUser', 'ga:browser', 'ga:operatingSystem', 'ga:country', 
+                'ga:city', 'ga:language', 'ga:date', 'ga:year', 'ga:month', 'ga:hour'
             },
-            "Audience Geo Location": set(),
+            "Audience Geo Location": {
+                'ga:users', 'ga:newUsers', 'ga:sessions', 'ga:bounceRate', 'ga:avgSessionDuration', 'ga:pageviewsPerSession',
+                'ga:continent', 'ga:subContinent', 'ga:country', 'ga:city', 'ga:date', 'ga:year', 'ga:month', 'ga:hour'
+            },
             "Audience Technology": set(),
-            "Acquisition Overview": set(),
+            "Acquisition Overview": {
+                "ga:sessions", 'ga:bounceRate', 'ga:avgSessionDuration', 'ga:pageviewsPerSession', 
+                'ga:acquisitionMedium', 'ga:acquisitionSource', 'ga:acquisitionSourceMedium', 
+                'ga:acquisitionTrafficChannel'
+            },
             "Behavior Overview": set(),
             "Ecommerce Overview": set(),
         }

--- a/tests/base.py
+++ b/tests/base.py
@@ -32,6 +32,7 @@ class GoogleAnalyticsBaseTest(unittest.TestCase):
     FULL_TABLE = "FULL_TABLE"
     START_DATE_FORMAT = "%Y-%m-%dT00:00:00Z"
     REPLICATION_KEY_FORMAT = "%Y-%m-%dT00:00:00.000000Z"
+    PAGE_SIZE = 1000
 
     start_date = ""
 
@@ -51,7 +52,7 @@ class GoogleAnalyticsBaseTest(unittest.TestCase):
             'start_date' : (dt.utcnow() - timedelta(days=30)).strftime(self.START_DATE_FORMAT),
             'view_id': os.getenv('TAP_GOOGLE_ANALYTICS_VIEW_ID'),
             'report_definitions': [{"id": "a665732c-d18b-445c-89b2-5ca8928a7305", "name": "Test Report 1"}],
-            'page_size': 1
+            'page_size': self.PAGE_SIZE
         }
         if original:
             return return_value
@@ -437,23 +438,22 @@ class GoogleAnalyticsBaseTest(unittest.TestCase):
     @staticmethod
     def expected_pagination_fields():
         return {
-            "Test Report 1" : set(),
+            "Test Report 1" : {
+                'ga:userType', 'ga:sessionCount', 'ga:daysSinceLastSession', 'ga:exitPagePath', 'ga:previousPagePath'
+            },
             "Audience Overview": {
-                'ga:users', 'ga:newUsers', 'ga:sessions', 'ga:bounceRate', 'ga:avgSessionDuration', 'ga:pageviews', 
-                'ga:pageviewsPerSession', 'ga:sessionsPerUser', 'ga:browser', 'ga:operatingSystem', 'ga:country', 
-                'ga:city', 'ga:language', 'ga:date', 'ga:year', 'ga:month', 'ga:hour'
+                'ga:browser', 'ga:operatingSystem', 'ga:country', 'ga:city', 'ga:language', 'ga:year', 'ga:month', 'ga:hour'
             },
             "Audience Geo Location": {
-                'ga:users', 'ga:newUsers', 'ga:sessions', 'ga:bounceRate', 'ga:avgSessionDuration', 'ga:pageviewsPerSession',
-                'ga:continent', 'ga:subContinent', 'ga:country', 'ga:city', 'ga:date', 'ga:year', 'ga:month', 'ga:hour'
+                'ga:year', 'ga:month', 'ga:hour'
             },
             "Audience Technology": set(),
             "Acquisition Overview": {
-                "ga:sessions", 'ga:bounceRate', 'ga:avgSessionDuration', 'ga:pageviewsPerSession', 
-                'ga:acquisitionMedium', 'ga:acquisitionSource', 'ga:acquisitionSourceMedium', 
-                'ga:acquisitionTrafficChannel'
+                'ga:acquisitionMedium', 'ga:acquisitionSource', 'ga:acquisitionSourceMedium', 'ga:acquisitionTrafficChannel'
             },
-            "Behavior Overview": set(),
+            "Behavior Overview": {
+                "ga:year", "ga:month", "ga:hour",
+            },
             "Ecommerce Overview": set(),
         }
 

--- a/tests/test_google_analytics_pagination.py
+++ b/tests/test_google_analytics_pagination.py
@@ -2,93 +2,102 @@
 ### TODO WAITING ON https://stitchdata.atlassian.net/browse/SRCE-5065
 ##########################################################################
 
-# import os
+import os
 
-# from datetime import timedelta
-# from datetime import datetime as dt
+from datetime import timedelta
+from datetime import datetime as dt
 
-# from  tap_tester import connections, runner
+from  tap_tester import connections, runner
 
-# from base import GoogleAnalyticsBaseTest
-
-
-# class GoogleAnalyticsPaginationTest(GoogleAnalyticsBaseTest):
-#     """Test that we are paginating for streams when exceeding the API record limit of a single query"""
-
-#     @staticmethod
-#     def name():
-#         return "tap_tester_google_analytics_pagination_test"
+from base import GoogleAnalyticsBaseTest
 
 
-#     def test_run(self):
-#         """
-#         Verify that for each report you can get multiple pages of data for a given date.
+class GoogleAnalyticsPaginationTest(GoogleAnalyticsBaseTest):
+    """Test that we are paginating for streams when exceeding the API record limit of a single query"""
 
-#         PREREQUISITE
-#         For EACH report, a dimension must be selected in which the number of distinct values is
-#         greater than the default value of maxResults (page size).
-#         """
-#         self.start_date = (dt.utcnow() - timedelta(days=4)).strftime(self.START_DATE_FORMAT) # Needs to be prior to isGolden..
-#         API_LIMIT = {stream: 1000 for stream in self.expected_sync_streams()}
-#         expected_streams = {'Audience Overview', 'report 1'}  # self.expected_sync_streams()
-
-#         # Create connection but do not use default start date
-#         conn_id = connections.ensure_connection(self, original_properties=False)
-
-#         # run check mode
-#         found_catalogs = self.run_and_verify_check_mode(conn_id)
-
-#         # TODO remove once all streams covered
-#         found_catalogs = [catalog for catalog in found_catalogs
-#                           if catalog.get('stream_name') in expected_streams]
-
-#         # TODO select specific streams
-#         # table and field selection
-#         self.perform_and_verify_table_and_field_selection(
-#             conn_id, found_catalogs, select_all_fields=True,
-#             #select_default_fields=False, select_pagination_fields=True
-#         )
+    API_LIMIT = 1
+    
+    @staticmethod
+    def name():
+        return "tap_tester_google_analytics_pagination_test"
 
 
-#         # run initial sync
-#         record_count_by_stream = self.run_and_verify_sync(conn_id)
+    def test_run(self):
+        """
+        Verify that for each report you can get multiple pages of data for a given date.
 
-#         synced_records = runner.get_records_from_target_output()
-#         import pdb; pdb.set_trace()
-#         #  messages1 = synced_records['Audience Overview']['messages']
-#         messages2 = synced_records['report 1']['messages']
+        PREREQUISITE
+        For EACH report, a dimension must be selected in which the number of distinct values is
+        greater than the default value of maxResults (page size).
+        """
+        self.start_date = (dt.utcnow() - timedelta(days=4)).strftime(self.START_DATE_FORMAT) # Needs to be prior to isGolden..
+        
+        expected_streams = {'Acquisition Overview', 'Audience Geo Location', 'Audience Overview'}
 
-#         # m1_25 = [m for m in messages1 if m['data']['start_date'] == '2021-02-25T00:00:00.000000Z' ]
-#         # m1_26 = [m for m in messages1 if m['data']['start_date'] == '2021-02-26T00:00:00.000000Z' ]
-#         # m1_27 = [m for m in messages1 if m['data']['start_date'] == '2021-02-27T00:00:00.000000Z' ]
-#         # m1_28 = [m for m in messages1 if m['data']['start_date'] == '2021-02-28T00:00:00.000000Z' ]
+        # Create connection but do not use default start date
+        conn_id = connections.ensure_connection(self, original_properties=False)
 
-#         m2_25 = [m for m in messages2 if m['data']['start_date'] == '2021-02-25T00:00:00.000000Z' ]
-#         m2_26 = [m for m in messages2 if m['data']['start_date'] == '2021-02-26T00:00:00.000000Z' ]
-#         m2_27 = [m for m in messages2 if m['data']['start_date'] == '2021-02-27T00:00:00.000000Z' ]
-#         m2_28 = [m for m in messages2 if m['data']['start_date'] == '2021-02-28T00:00:00.000000Z' ]
+        # run check mode
+        found_catalogs = self.run_and_verify_check_mode(conn_id)
 
-#         for stream in expected_streams:
-#             with self.subTest(stream=stream):
+        # TODO remove once all streams covered
+        found_catalogs = [catalog for catalog in found_catalogs
+                          if catalog.get('stream_name') in expected_streams]
 
-#                 # TODO Verify we are paginating for testable synced streams
-#                 self.assertGreater(record_count_by_stream.get(stream, -1), API_LIMIT.get(stream),
-#                                    msg="We didn't guarantee pagination. The number of records should exceed the api limit.")
+        # TODO select specific streams
+        # table and field selection
+        self.perform_and_verify_table_and_field_selection(
+            conn_id, found_catalogs, #select_all_fields=True,
+            select_default_fields=False, select_pagination_fields=True
+        )
 
-#                 data = synced_records.get(stream, [])
-#                 actual_records = [row['data'] for row in data['messages']]
-#                 record_messages_keys = [set(row['data'].keys()) for row in data['messages']]
-#                 auto_fields = self.expected_automatic_fields().get(stream)
 
-#                 for actual_keys in record_messages_keys:
+        # run initial sync
+        record_count_by_stream = self.run_and_verify_sync(conn_id)
 
-#                     # Verify that the automatic fields are sent to the target for paginated streams
-#                     self.assertTrue(auto_fields.issubset(actual_keys),
-#                                     msg="A paginated synced stream has a record that is missing automatic fields.")
+        synced_records = runner.get_records_from_target_output()
 
-#                     # Verify we have more fields sent to the target than just automatic fields (this is set above)
-#                     self.assertEqual(set(), auto_fields.difference(actual_keys),
-#                                      msg="A paginated synced stream has a record that is missing expected fields.")
+        # Verify no unexpected streams were replicated
+        synced_stream_names = set(synced_records.keys())
+        self.assertSetEqual(expected_streams, synced_stream_names)
 
-#                 # TODO Verify by pks that the replicated records match our expectations
-#                 # self.assertPKsEqual(stream, expected_records.get(stream), actual_records)
+        for stream in expected_streams:
+            with self.subTest(stream=stream):
+
+                # expected values
+                expected_primary_keys = self.expected_primary_keys()[stream]
+
+                # TODO Verify we are paginating for testable synced streams
+                self.assertGreater(record_count_by_stream.get(stream, -1), self.API_LIMIT,
+                                   msg="We didn't guarantee pagination. The number of records should exceed the api limit.")
+
+                data = synced_records.get(stream, [])
+                record_messages_keys = [set(row['data'].keys()) for row in data['messages']]
+                auto_fields = self.expected_automatic_fields().get(stream)
+
+                for actual_keys in record_messages_keys:
+
+                    # Verify that the automatic fields are sent to the target for paginated streams
+                    self.assertTrue(auto_fields.issubset(actual_keys),
+                                    msg="A paginated synced stream has a record that is missing automatic fields.")
+
+                    # Verify we have more fields sent to the target than just automatic fields (this is set above)
+                    self.assertEqual(set(), auto_fields.difference(actual_keys),
+                                     msg="A paginated synced stream has a record that is missing expected fields.")
+
+                
+                messages = synced_records[stream]['messages']
+                start_date_messages = [m for m in messages if m['data']['start_date'] == self.start_date ]
+                primary_keys_list = [tuple([message.get('data').get(expected_pk) for expected_pk in expected_primary_keys])
+                                        for message in start_date_messages
+                                        if message.get('action') == 'upsert']
+
+                primary_keys_list_1 = primary_keys_list[:self.API_LIMIT]
+                primary_keys_list_2 = primary_keys_list[self.API_LIMIT:2*self.API_LIMIT]
+
+                primary_keys_page_1 = set(primary_keys_list_1)
+                primary_keys_page_2 = set(primary_keys_list_2)
+
+                # Verify by primary keys that data is unique for page
+                self.assertTrue(
+                    primary_keys_page_1.isdisjoint(primary_keys_page_2))

--- a/tests/unittests/test_sync_utilities.py
+++ b/tests/unittests/test_sync_utilities.py
@@ -9,6 +9,7 @@ from tap_google_analytics.sync import sync_report, generate_sdc_record_hash
 reports = None
 error_after = None
 reports_synced = 0
+DEFAULT_PAGE_SIZE = 1000
 
 def get_mock_report(name, profile_id, report_date, metrics, dimensions):
     global reports_synced
@@ -48,7 +49,8 @@ class TestIsDataGoldenBookmarking(unittest.TestCase):
                     {"id": "123", "name":"test_report", "profile_id": "12345", "metrics":[], "dimensions":[]},
                     utils.strptime_to_utc("2019-11-01"),
                     utils.strptime_to_utc("2019-11-04"),
-                    state)
+                    state,
+                    DEFAULT_PAGE_SIZE)
         # Ensure we stopped bookmarking at third day
         self.assertEqual({'bookmarks': {'123': {'12345': {'last_report_date': '2019-11-03'}}}}, state)
         # Ensure we paginated through all 4 days, not stopping at third
@@ -64,7 +66,8 @@ class TestIsDataGoldenBookmarking(unittest.TestCase):
                     {"id": "123", "name":"test_report", "profile_id": "12345", "metrics":[], "dimensions":[]},
                     utils.strptime_to_utc("2019-11-03"),
                     utils.strptime_to_utc("2019-11-03"),
-                    state)
+                    state,
+                    DEFAULT_PAGE_SIZE)
         self.assertEqual({'bookmarks': {'123': {'12345': {'last_report_date': '2019-11-03'}}}}, state)
         self.assertEqual(self.client.get_report.call_count, 1)
 
@@ -93,6 +96,7 @@ class TestIsDataGoldenBookmarking(unittest.TestCase):
                     utils.strptime_to_utc("2019-10-30"),
                     utils.strptime_to_utc("2019-11-04"),
                     state,
+                    DEFAULT_PAGE_SIZE,
                     historically_syncing=True)
         self.assertEqual({'bookmarks': {'123': {'12345': {'last_report_date': '2019-11-03'}}}}, state)
         self.assertEqual(self.client.get_report.call_count, 6)
@@ -124,6 +128,7 @@ class TestIsDataGoldenBookmarking(unittest.TestCase):
                         utils.strptime_to_utc("2019-10-30"),
                         utils.strptime_to_utc("2019-11-02"),
                         state,
+                        DEFAULT_PAGE_SIZE,
                         historically_syncing=True)
         self.assertEqual({}, state)
         self.assertEqual(self.client.get_report.call_count, 4)

--- a/tests/unittests/test_sync_utilities.py
+++ b/tests/unittests/test_sync_utilities.py
@@ -11,7 +11,7 @@ error_after = None
 reports_synced = 0
 DEFAULT_PAGE_SIZE = 1000
 
-def get_mock_report(name, profile_id, report_date, metrics, dimensions):
+def get_mock_report(name, profile_id, report_date, metrics, dimensions, page_size):
     global reports_synced
     if error_after and reports_synced == error_after:
         raise Exception("Report failed!")


### PR DESCRIPTION
# Description of change
- Updated pagination parameter configurable.
- Added pagination test case.

# QA steps
 - Give the `page_size` parameter in the config and verify that tap calls the API with the given pagination parameter.
 - Verify that if `page_size` parameter is not provided then tap consider default `page_size` 1000.
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
