### PR TITLE
Allow strings in datetime fields that are not dates to be synced

### DIFF
--- a/tap_google_analytics/discover.py
+++ b/tap_google_analytics/discover.py
@@ -46,7 +46,14 @@ float_field_overrides = {'ga:latitude',
 # pylint: disable=too-many-return-statements
 def type_to_schema(ga_type, field_id):
     if field_id in datetime_field_overrides:
-        return {"type": ["string", "null"], "format": "date-time"}
+        # datetime is not always a valid datetime string
+        # https://support.google.com/analytics/answer/9309767
+        return {
+            "anyOf": [
+                {"type": ["string", "null"], "format": "date-time"},
+                {"type": ["string", "null"]}
+            ]
+        }
     elif ga_type == 'CURRENCY':
         # https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters#ecomm
         return {"type": ["number", "null"]}

--- a/tap_google_analytics/sync.py
+++ b/tap_google_analytics/sync.py
@@ -111,7 +111,7 @@ def transform_datetimes(report_name, rec):
     for field_name, value in rec.items():
         if value and field_name in DATETIME_FORMATS:
             rec[field_name], is_valid_datetime = parse_datetime(field_name, value)
-            row_limit_reached = row_limit_reached or not is_valid_datetime
+            row_limit_reached = row_limit_reached or (not is_valid_datetime and value == "(other)")
     if row_limit_reached:
         LOGGER.warning(f"Row limit reached for report: {report_name}. See https://support.google.com/analytics/answer/9309767 for more info.")
     return rec


### PR DESCRIPTION
# Description of change
It is possible to get `(other)` as a value from Google for certain fields. This becomes a problem with the date fields because they expect a string formatted as a date/datetime.

This happens because the cardinality of the dimensions selected on the report cause the underlying database to reach its row limit. The data beyond that limit is then put into this `(other)` group.

See this for a more detailed explanation on `(other)` values:
https://support.google.com/analytics/answer/9309767

This PR fixes this by:
- allowing date fields either a date or a string in the schema
- catching errors when parsing datetimes and putting the original value in the record

# QA steps
 - [x] automated tests passing
 - [x] manual qa steps passing (list below)
   - Used connection with `(other)` values to ensure proper functionality
 
# Risks
 - The `sdc_record_hash` is the same for all the `(other)` rows
   - This is to be expected since Google also groups all these into one row
   - There is a chance the last values updated for the `(other)` row is not the latest, depending on the order of them in the response. See example below.

This is the order these records were received. They have the same `sdc_record_hash` and different values for the metrics.
```
{
  "ga:city": "(other)",
  "ga:country": "(other)",
  "ga:date": "(other)",
  "ga:productName": "(other)",
  "ga:productSku": "(other)",
  "ga:sessionCount": "(other)",
  "ga:sourceMedium": "(other)",
  "ga:productAddsToCart": 831,
  "ga:productDetailViews": 8256,
  "ga:productListClicks": 4466,
  "ga:sessionsPerUser": 0,
  "ga:uniquePurchases": 64,
  "ga:users": 162907,
  "_sdc_record_hash": "3ed0deb9cfa121a47fce5f5ef2e281e2777fdb3fee2047db88980a1c3b8240d5",
  "start_date": "2022-01-18T00:00:00.000000Z",
  "end_date": "2022-01-18T00:00:00.000000Z",
  "account_id": "12345678",
  "web_property_id": "AA-09876543-1",
  "profile_id": "987654321"
}
{
  "ga:city": "(other)",
  "ga:country": "(other)",
  "ga:date": "(other)",
  "ga:productName": "(other)",
  "ga:productSku": "(other)",
  "ga:sessionCount": "(other)",
  "ga:sourceMedium": "(other)",
  "ga:productAddsToCart": 777,
  "ga:productDetailViews": 8468,
  "ga:productListClicks": 4416,
  "ga:sessionsPerUser": 0,
  "ga:uniquePurchases": 74,
  "ga:users": 162651,
  "_sdc_record_hash": "3ed0deb9cfa121a47fce5f5ef2e281e2777fdb3fee2047db88980a1c3b8240d5",
  "start_date": "2022-01-18T00:00:00.000000Z",
  "end_date": "2022-01-18T00:00:00.000000Z",
  "account_id": "12345678",
  "web_property_id": "AA-09876543-1",
  "profile_id": "987654321"
}
```

# Rollback steps
 - revert this branch
